### PR TITLE
Improve tracing

### DIFF
--- a/lib/asimov-core/Cargo.toml
+++ b/lib/asimov-core/Cargo.toml
@@ -22,10 +22,11 @@ std = [
     "asimov-sys/std",
     "dogma/std",
     "protoflow-core/std",
+    "tracing?/std",
     "dep:cap-directories",
     "dep:cap-std",
 ]
-tracing = ["protoflow-core/tracing"]
+tracing = ["dep:tracing", "protoflow-core/tracing"]
 unstable = []
 
 [dependencies]
@@ -39,3 +40,4 @@ know.workspace = true
 protoflow-core.workspace = true
 serde = { version = "1.0", default-features = false, optional = true }
 stability.workspace = true
+tracing = { version = "0.1", default-features = false, optional = true }

--- a/lib/asimov-core/src/lib.rs
+++ b/lib/asimov-core/src/lib.rs
@@ -54,3 +54,23 @@ pub mod crates {
     #[cfg(feature = "serde")]
     pub use ::serde;
 }
+
+#[cfg(feature = "tracing")]
+#[doc(hidden)]
+mod tracing {
+    pub use tracing::{debug, error, info, trace, warn};
+}
+
+#[cfg(not(feature = "tracing"))]
+#[doc(hidden)]
+#[rustfmt::skip]
+mod tracing {
+    #[macro_export] macro_rules! debug { ($($arg:tt)+) => (); }
+    #[macro_export] macro_rules! error { ($($arg:tt)+) => (); }
+    #[macro_export] macro_rules! info { ($($arg:tt)+) => (); }
+    #[macro_export] macro_rules! trace { ($($arg:tt)+) => (); }
+    #[macro_export] macro_rules! warn { ($($arg:tt)+) => (); }
+}
+
+#[allow(unused)]
+pub use tracing::*;

--- a/lib/asimov-core/src/lib.rs
+++ b/lib/asimov-core/src/lib.rs
@@ -65,6 +65,8 @@ mod tracing {
 #[doc(hidden)]
 #[rustfmt::skip]
 mod tracing {
+    // These macros are fallback implementations used when the `tracing` feature is disabled.
+    // They are no-op definitions to ensure that code using these macros compiles without errors.
     #[macro_export] macro_rules! debug { ($($arg:tt)+) => (); }
     #[macro_export] macro_rules! error { ($($arg:tt)+) => (); }
     #[macro_export] macro_rules! info { ($($arg:tt)+) => (); }

--- a/lib/asimov-flow/Cargo.toml
+++ b/lib/asimov-flow/Cargo.toml
@@ -21,7 +21,7 @@ derive = ["protoflow/derive"]
 serde = ["asimov-core/serde", "protoflow/serde", "dep:serde"]
 std = ["asimov-core/std", "protoflow/std"]
 tokio = ["protoflow/tokio"]
-tracing = ["protoflow/tracing", "dep:tracing"]
+tracing = ["protoflow/tracing", "protoflow-blocks/tracing"]
 unstable = ["asimov-core/unstable"]
 yaml = ["serde", "dep:serde_yml"]
 
@@ -32,4 +32,3 @@ protoflow-blocks.workspace = true
 serde = { version = "1.0", default-features = false, optional = true }
 serde_yml = { version = "0.0.11", default-features = false, optional = true }
 stability.workspace = true
-tracing = { version = "0.1", default-features = false, optional = true }

--- a/lib/asimov-sdk/Cargo.toml
+++ b/lib/asimov-sdk/Cargo.toml
@@ -19,15 +19,9 @@ default = ["all", "std"]
 all = ["derive", "serde", "tracing"]
 derive = ["protoflow/derive"]
 serde = ["asimov-core/serde", "protoflow/serde"]
-std = [
-    "asimov-core/std",
-    "asimov-sys/std",
-    "protoflow/std",
-    "tokio?/full",
-    "tracing?/std",
-]
+std = ["asimov-core/std", "asimov-sys/std", "protoflow/std", "tokio?/full"]
 tokio = ["protoflow/tokio", "dep:tokio"]
-tracing = ["protoflow/tracing", "dep:tracing"]
+tracing = ["protoflow/tracing", "protoflow-blocks/tracing"]
 unstable = ["asimov-core/unstable", "asimov-sys/unstable"]
 web = ["protoflow/web"]
 
@@ -41,7 +35,6 @@ protoflow.workspace = true
 protoflow-blocks.workspace = true
 stability.workspace = true
 tokio = { version = "1.38", default-features = false, optional = true }
-tracing = { version = "0.1", default-features = false, optional = true }
 
 [target.'cfg(not(wasm))'.dependencies]
 


### PR DESCRIPTION
This PR adds conveniently exported tracing macros to `asimov-core` package allowing other packages use tracing without needing of `#[cfg(feature = "tracing")]` guard or even having tracing as dependency.
It also removes `tracing` dependency from other packages and makes sure all features related to tracing are properly implemented in `Cargo.toml` of all packages.