### PR TITLE
Initial mDNS implementation

### DIFF
--- a/lib/asimov-server/Cargo.toml
+++ b/lib/asimov-server/Cargo.toml
@@ -24,7 +24,7 @@ unstable = ["https", "mdns", "ssdp"]
 # Protocols:
 http = ["dep:axum", "dep:axum-prometheus", "dep:tower-http"]
 https = ["http"]
-mdns = []
+mdns = ["dep:mdns-sd", "dep:lazy_static", "dep:local-ip-address"]
 ssdp = []
 
 # Protocols on top of HTTP:
@@ -45,6 +45,19 @@ tower-http = { version = "0.6", default-features = false, features = [
     "cors",
 ], optional = true }
 tracing = { version = "0.1", optional = true }
+mdns-sd = { version = "0.13", optional = true }
+lazy_static = { version = "1.5", optional = true }
+local-ip-address = { version = "0.6", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+
+[[example]]
+name = "mdns-client"
+path = "examples/mdns-client.rs"
+required-features = ["mdns"]
+
+[[example]]
+name = "mdns-server"
+path = "examples/mdns-server.rs"
+required-features = ["mdns"]

--- a/lib/asimov-server/examples/mdns-client.rs
+++ b/lib/asimov-server/examples/mdns-client.rs
@@ -1,0 +1,29 @@
+// This is free and unencumbered software released into the public domain.
+
+use asimov_server::mdns::{self, ServiceEvent};
+
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let receiver = mdns::browse()?;
+
+    for event in receiver {
+        match event {
+            ServiceEvent::SearchStarted(ty) => {
+                println!("Search started for service of type {}", ty);
+            }
+            ServiceEvent::ServiceFound(ty, name) => {
+                println!("Found service of type {} with name {}", ty, name);
+            }
+            ServiceEvent::ServiceResolved(info) => {
+                println!("Resolved service: {:?}", info);
+            }
+            ServiceEvent::ServiceRemoved(ty, name) => {
+                println!("Service of type {} with name {} removed", ty, name);
+            }
+            ServiceEvent::SearchStopped(ty) => {
+                println!("Search stopped for service of type {}", ty);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/lib/asimov-server/examples/mdns-server.rs
+++ b/lib/asimov-server/examples/mdns-server.rs
@@ -1,0 +1,10 @@
+// This is free and unencumbered software released into the public domain.
+
+use asimov_server::mdns;
+
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    mdns::register()?;
+
+    std::thread::sleep(std::time::Duration::MAX);
+    Ok(())
+}

--- a/lib/asimov-server/src/mdns.rs
+++ b/lib/asimov-server/src/mdns.rs
@@ -1,1 +1,38 @@
 // This is free and unencumbered software released into the public domain.
+
+use lazy_static::lazy_static;
+use local_ip_address::local_ip;
+use mdns_sd::ServiceDaemon;
+
+pub use mdns_sd::{Receiver, Result, ServiceEvent, ServiceInfo};
+
+pub static SERVICE_TYPE: &str = "_asimov._udp.local.";
+
+lazy_static! {
+    static ref DAEMON: ServiceDaemon = ServiceDaemon::new().expect("Failed to create mDNS daemon");
+}
+
+pub fn register() -> Result<()> {
+    let ip = local_ip().unwrap();
+    let host_name = format!("{}.local.", ip);
+
+    let info = ServiceInfo::new(
+        SERVICE_TYPE,
+        "asimov-server",
+        host_name.as_str(),
+        ip,
+        1920,
+        None,
+    )?;
+
+    DAEMON.register(info)
+}
+
+pub fn shutdown() -> Result<()> {
+    DAEMON.shutdown()?;
+    Ok(())
+}
+
+pub fn browse() -> Result<Receiver<ServiceEvent>> {
+    DAEMON.browse(SERVICE_TYPE)
+}


### PR DESCRIPTION
This PR adds a simple mDNS implementation to discover other instances of asimov-server in the same network.

@race-of-sloths include