### PR TITLE
Implement persistent state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 /Cargo.lock
 /rust-toolchain
 /target
+
+# Persistence
+persistence.json

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,3 @@
 /Cargo.lock
 /rust-toolchain
 /target
-
-# Persistence
-persistence.json

--- a/lib/asimov-server/Cargo.toml
+++ b/lib/asimov-server/Cargo.toml
@@ -33,7 +33,7 @@ gsp = ["http"]
 sparql = ["http"]
 
 # Other:
-persistence = ["dep:serde", "dep:serde_json", "dep:lazy_static"]
+persistence = ["dep:serde", "dep:serde_json"]
 
 [dependencies]
 asimov-runner.workspace = true

--- a/lib/asimov-server/Cargo.toml
+++ b/lib/asimov-server/Cargo.toml
@@ -22,7 +22,7 @@ tracing = ["dep:tracing"]
 unstable = ["https", "mdns", "ssdp"]
 
 # Protocols:
-http = ["dep:axum", "dep:axum-prometheus", "dep:tower-http"]
+http = ["persistence", "dep:axum", "dep:axum-prometheus", "dep:tower-http"]
 https = ["http"]
 mdns = ["dep:mdns-sd", "dep:lazy_static", "dep:local-ip-address"]
 ssdp = []
@@ -31,6 +31,9 @@ ssdp = []
 graphql = ["http"]
 gsp = ["http"]
 sparql = ["http"]
+
+# Other:
+persistence = ["dep:serde", "dep:serde_json", "dep:lazy_static"]
 
 [dependencies]
 asimov-runner.workspace = true
@@ -52,6 +55,8 @@ tower-http = { version = "0.6", default-features = false, features = [
     "cors",
 ], optional = true }
 tracing = { workspace = true, optional = true }
+serde = { version = "1", optional = true, features = ["derive"] }
+serde_json = { version = "1", optional = true }
 uuid.workspace = true
 
 [dev-dependencies]
@@ -66,3 +71,8 @@ required-features = ["mdns"]
 name = "mdns-server"
 path = "examples/mdns-server.rs"
 required-features = ["mdns"]
+
+[[example]]
+name = "persistence"
+path = "examples/persistence.rs"
+required-features = ["http", "persistence"]

--- a/lib/asimov-server/examples/persistence.rs
+++ b/lib/asimov-server/examples/persistence.rs
@@ -1,0 +1,21 @@
+use std::io::Write;
+
+use asimov_server::persistence;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let state = persistence::get();
+    println!("{state:?}");
+
+    print!("Select new provider: ");
+    std::io::stdout().flush()?;
+
+    let mut provider = String::new();
+    std::io::stdin().read_line(&mut provider)?;
+    provider = provider.trim().to_string();
+
+    persistence::set(|x| {
+        x.provider = provider;
+    })?;
+
+    Ok(())
+}

--- a/lib/asimov-server/src/http/openai_v1/completions.rs
+++ b/lib/asimov-server/src/http/openai_v1/completions.rs
@@ -2,6 +2,10 @@
 
 #![allow(unused_imports)]
 
+use std::sync::{Arc, RwLock};
+
+use crate::persistence::{self, PersistentState};
+
 use super::error::CompletionError;
 use asimov_runner::{Execute, Prompt, Provider, ProviderOptions};
 use axum::{Json, Router, extract, routing::post};
@@ -13,12 +17,15 @@ use openai::schemas::{
 
 /// See: https://platform.openai.com/docs/api-reference/completions
 pub fn routes() -> Router {
-    Router::new().route("/", post(create))
+    Router::new()
+        .route("/", post(create))
+        .with_state(persistence::get_ref())
 }
 
 /// See: https://platform.openai.com/docs/api-reference/completions/create
 #[axum::debug_handler]
 async fn create(
+    extract::State(state): extract::State<Arc<RwLock<PersistentState>>>,
     extract::Json(request): extract::Json<CreateCompletionRequest>,
 ) -> Result<Json<CreateCompletionResponse>, CompletionError> {
     if request.model.is_empty() {
@@ -28,8 +35,9 @@ async fn create(
         return Err(CompletionError::EmptyPrompt);
     }
 
+    let provider_name = state.read().unwrap().provider.clone();
     let mut provider = Provider::new(
-        "asimov-default-provider",
+        provider_name,
         ProviderOptions {
             prompt: Prompt::try_from(request.prompt.unwrap()).map_err(|_| {
                 CompletionError::UnimplementedFeature("prompt from an array of tokens".into())

--- a/lib/asimov-server/src/lib.rs
+++ b/lib/asimov-server/src/lib.rs
@@ -6,6 +6,9 @@ pub use tokio_util::sync::CancellationToken;
 #[cfg(feature = "http")]
 pub mod http;
 
+#[cfg(feature = "persistence")]
+pub mod persistence;
+
 #[cfg(feature = "mdns")]
 pub mod mdns;
 

--- a/lib/asimov-server/src/persistence.rs
+++ b/lib/asimov-server/src/persistence.rs
@@ -1,7 +1,10 @@
 // This is free and unencumbered software released into the public domain.
 
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, LazyLock, RwLock};
+use std::{
+    path::PathBuf,
+    sync::{Arc, LazyLock, RwLock},
+};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -30,18 +33,24 @@ impl Default for PersistentState {
     }
 }
 
-static FILE_NAME: &str = "persistence.json";
+/// Get the path to persistence file.
+fn get_file_path() -> Result<PathBuf> {
+    let current_dir = std::env::current_exe()?;
+    Ok(current_dir.with_file_name("persistence.json"))
+}
 
 /// Read the persistent state from the file.
 fn read() -> Result<PersistentState> {
-    let file = std::fs::File::open(FILE_NAME)?;
+    let path = get_file_path()?;
+    let file = std::fs::File::open(path)?;
     let reader = std::io::BufReader::new(file);
     Ok(serde_json::from_reader(reader)?)
 }
 
 /// Write the persistent state to the file.
 fn write(state: &PersistentState) -> Result<()> {
-    let file = std::fs::File::create(FILE_NAME)?;
+    let path = get_file_path()?;
+    let file = std::fs::File::create(path)?;
     let writer = std::io::BufWriter::new(file);
     serde_json::to_writer(writer, state)?;
     Ok(())

--- a/lib/asimov-server/src/persistence.rs
+++ b/lib/asimov-server/src/persistence.rs
@@ -1,0 +1,73 @@
+// This is free and unencumbered software released into the public domain.
+
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, LazyLock, RwLock};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("failed to read or write")]
+    IoError(#[from] std::io::Error),
+    #[error("failed to serialize or deserialize")]
+    SerdeError(#[from] serde_json::Error),
+}
+pub type Result<T> = std::result::Result<T, Error>;
+
+static STATE: LazyLock<Arc<RwLock<PersistentState>>> =
+    LazyLock::new(|| Arc::new(RwLock::new(read().unwrap_or_default())));
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct PersistentState {
+    pub provider: String,
+}
+
+impl Default for PersistentState {
+    fn default() -> Self {
+        Self {
+            provider: "asimov-default-provider".into(),
+        }
+    }
+}
+
+static FILE_NAME: &str = "persistence.json";
+
+/// Read the persistent state from the file.
+fn read() -> Result<PersistentState> {
+    let file = std::fs::File::open(FILE_NAME)?;
+    let reader = std::io::BufReader::new(file);
+    Ok(serde_json::from_reader(reader)?)
+}
+
+/// Write the persistent state to the file.
+fn write(state: &PersistentState) -> Result<()> {
+    let file = std::fs::File::create(FILE_NAME)?;
+    let writer = std::io::BufWriter::new(file);
+    serde_json::to_writer(writer, state)?;
+    Ok(())
+}
+
+/// Get the reference to persistent state.
+pub(crate) fn get_ref() -> Arc<RwLock<PersistentState>> {
+    STATE.clone()
+}
+
+/// Get the copy of current persistent state.
+pub fn get() -> PersistentState {
+    STATE.read().unwrap().clone()
+}
+
+/// Set the persistent state.
+///
+/// This method updates the persistent state
+/// and writes it to the file _immediately_!
+///
+/// This method is thread-safe.
+pub fn set<F>(x: F) -> Result<()>
+where
+    F: FnOnce(&mut PersistentState),
+{
+    let mut state = STATE.write().unwrap();
+    x(&mut state);
+    write(&state)
+}


### PR DESCRIPTION
This PR implements a persistent state that is used by OpenAI API in `http` module, but can be used in any place and can be accessed and modified thread-safely by anyone, including dependent crates.

@race-of-sloths include