### PR TITLE
Fix `PythonEnv::initialize`

### DIFF
--- a/lib/asimov-env/src/envs/python.rs
+++ b/lib/asimov-env/src/envs/python.rs
@@ -52,8 +52,18 @@ impl Env for PythonEnv {
         // Create the directory if it doesn't exist:
         std::fs::create_dir_all(path)?;
 
+        let mut python = if self
+            .venv
+            .as_ref()
+            .is_some_and(|path| path.join("bin").join("python3").exists())
+        {
+            self.python()
+        } else {
+            Command::new(python().unwrap().as_ref())
+        };
+
         // Create the venv if it doesn't exist:
-        self.python()
+        python
             .args(["-m", "venv", path.to_str().unwrap()])
             .status()?;
 


### PR DESCRIPTION
The python env creation fails because `PythonEnv::python` always returns the python command at the configured path even if the venv doesn't exists yet:
```python
    pub fn python(&self) -> Command {
        match self.venv {
            None => Command::new(python().unwrap().as_ref()),
            Some(ref path) => {
                let mut command = Command::new(path.join("bin/python3"));
                command.env("VIRTUAL_ENV", path.as_os_str());
                command
            }
        }
    }
```

`PythonEnv::initialize` uses `self.python()` but naturally there isn't a runnable python at `$VENV/bin/python3`.

See before fix running `asimov-module-cli`:

```console
$ ls ~/.asimov/envs/python
ls: ~/.asimov/envs/python: No such file or directory

$ asimov module install mlx
error: failed to install module `mlx`: missing python environment

$ echo $?
69

$ ls ~/.asimov/envs/python
$ # ^ no error, the dir was created but the venv command afterwards failed
```

After fix:
```console
$ ls ~/.asimov/envs/python
ls: ~/.asimov/envs/python: No such file or directory

$ asimov module install mlx 2>/dev/null
$ # this also fails but this time due to errors specific to the asimov-mlx-module (/ my env) and not because of the venv
$ echo $?
70

$ ls ~/.asimov/envs/python
bin/        include/    lib/        pyvenv.cfg
$ # ^ venv created successfully
```

Alternative implementations considered:
- In `PythonEnv::python()` return the venv path python command only if it exists on disk. Doesn't look as nice because the venv path is set explicitly:
  
```rust
impl PythonEnv {
    pub fn system() -> Self {
        Self { venv: None }
    }

    pub fn at(path: PathBuf) -> Self {
        Self { venv: Some(path) }
    }

    pub fn python(&self) -> Command {
        match self.venv {
            None => Command::new(python().unwrap().as_ref()),
            Some(ref path) => {
                # <--- Add a check here to ensure bin/python3 exists --->
                let mut command = Command::new(path.join("bin/python3"));
                command.env("VIRTUAL_ENV", path.as_os_str());
                command
            }
        }
    }
```
- Change signature of either `PythonEnv::at` or `PythonEnv::python` to return `Result<T>` when the given path doesn't contain a valid venv. I think we'd like to avoid signature changes as much as possible?