### PR TITLE
Add a model representation of module manifest

### DIFF
--- a/lib/asimov-module/Cargo.toml
+++ b/lib/asimov-module/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings", "development-tools"]
 publish.workspace = true
 
 [features]
-default = ["all", "cli", "std"]
+default = ["all", "cli", "serde", "std"]
 all = ["tracing"]
 cli = ["std", "dep:clientele"]
 std = [
@@ -23,7 +23,7 @@ std = [
 	"clientele?/std",
 	"dogma/std",
 	"getenv?/std",
-	"serde/std",
+	"serde?/std",
 	"tracing?/std",
 	"tracing-subscriber?/fmt",
 	"tracing-subscriber?/std",
@@ -41,9 +41,11 @@ clientele = { workspace = true, features = [
 dogma.workspace = true
 getenv = { workspace = true, optional = true }
 secrecy.workspace = true
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-serde_yml = { version = "0.0.12", default-features = false }
+serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 trie-rs = { version = "0.4", default-features = false }
 url = { version = "2.5", default-features = false }
+
+[dev-dependencies]
+serde_yml = { version = "0.0.12", default-features = false }

--- a/lib/asimov-module/Cargo.toml
+++ b/lib/asimov-module/Cargo.toml
@@ -23,6 +23,7 @@ std = [
 	"clientele?/std",
 	"dogma/std",
 	"getenv?/std",
+	"serde/std",
 	"tracing?/std",
 	"tracing-subscriber?/fmt",
 	"tracing-subscriber?/std",
@@ -40,6 +41,7 @@ clientele = { workspace = true, features = [
 dogma.workspace = true
 getenv = { workspace = true, optional = true }
 secrecy.workspace = true
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_yml = { version = "0.0.12", default-features = false }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }

--- a/lib/asimov-module/examples/decode_manifest.rs
+++ b/lib/asimov-module/examples/decode_manifest.rs
@@ -1,10 +1,10 @@
 // This is free and unencumbered software released into the public domain.
 
-use asimov_module::models::Manifest;
+use asimov_module::models::ModuleManifest;
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let manifest = serde_yml::from_reader::<_, Manifest>(std::io::stdin())?;
+    let manifest = serde_yml::from_reader::<_, ModuleManifest>(std::io::stdin())?;
     print!("Debug print:\n\n{manifest:?}\n\n");
     print!("Re-encoded:\n\n");
     serde_yml::to_writer(std::io::stdout(), &manifest)?;

--- a/lib/asimov-module/examples/decode_manifest.rs
+++ b/lib/asimov-module/examples/decode_manifest.rs
@@ -1,14 +1,12 @@
 // This is free and unencumbered software released into the public domain.
 
 use asimov_module::models::Manifest;
-use std::{error::Error, io::Read};
+use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let mut input = String::new();
-    let _n = std::io::stdin().read_to_string(&mut input)?;
-    let manifest: Manifest = serde_yml::from_str(&input)?;
-    println!("Debug print:\n\n{manifest:?}");
-    let output = serde_yml::to_string(&manifest)?;
-    println!("\nRe-encoded:\n\n{output}");
+    let manifest = serde_yml::from_reader::<_, Manifest>(std::io::stdin())?;
+    print!("Debug print:\n\n{manifest:?}\n\n");
+    print!("Re-encoded:\n\n");
+    serde_yml::to_writer(std::io::stdout(), &manifest)?;
     Ok(())
 }

--- a/lib/asimov-module/examples/decode_manifest.rs
+++ b/lib/asimov-module/examples/decode_manifest.rs
@@ -1,0 +1,14 @@
+// This is free and unencumbered software released into the public domain.
+
+use asimov_module::models::Manifest;
+use std::{error::Error, io::Read};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut input = String::new();
+    let _n = std::io::stdin().read_to_string(&mut input)?;
+    let manifest: Manifest = serde_yml::from_str(&input)?;
+    println!("Debug print:\n\n{manifest:?}");
+    let output = serde_yml::to_string(&manifest)?;
+    println!("\nRe-encoded:\n\n{output}");
+    Ok(())
+}

--- a/lib/asimov-module/examples/resolver.rs
+++ b/lib/asimov-module/examples/resolver.rs
@@ -2,7 +2,7 @@
 
 use std::io::Write;
 
-use asimov_module::{models::Manifest, resolve::Resolver};
+use asimov_module::{models::ModuleManifest, resolve::Resolver};
 
 const YAMLS: &str = r#"
 name: near
@@ -16,7 +16,7 @@ links:
   - https://npmjs.com/package/asimov-near-module
 
 provides:
-  flows:
+  programs:
     - asimov-near-fetcher
 
 handles:
@@ -35,7 +35,7 @@ links:
   - https://npmjs.com/package/asimov-serpapi-module
 
 provides:
-  flows:
+  programs:
     - asimov-serpapi-fetcher
     - asimov-serpapi-importer
 
@@ -57,7 +57,7 @@ links:
     - https://npmjs.com/package/asimov-apify-module
 
 provides:
-    flows:
+    programs:
     - asimov-apify-fetcher
     - asimov-apify-importer
 
@@ -79,7 +79,7 @@ links:
     - https://npmjs.com/package/asimov-brightdata-module
 
 provides:
-    flows:
+    programs:
     - asimov-brightdata-fetcher
     - asimov-brightdata-importer
 
@@ -115,7 +115,7 @@ handles:
 fn main() {
     let manifests = YAMLS
         .split("---")
-        .map(serde_yml::from_str::<'_, Manifest>)
+        .map(serde_yml::from_str::<'_, ModuleManifest>)
         .map(Result::unwrap);
     let resolver = Resolver::try_from_iter(manifests).unwrap();
 

--- a/lib/asimov-module/examples/resolver.rs
+++ b/lib/asimov-module/examples/resolver.rs
@@ -2,9 +2,9 @@
 
 use std::io::Write;
 
-use asimov_module::resolve::ResolverBuilder;
+use asimov_module::{models::Manifest, resolve::ResolverBuilder};
 
-const YAMLS: &'static str = r#"
+const YAMLS: &str = r#"
 name: near
 label: NEAR Protocol
 summary: Data import from the NEAR Protocol blockchain network.
@@ -116,31 +116,17 @@ fn main() {
     let mut builder = ResolverBuilder::new();
 
     for module in YAMLS.split("---") {
-        let module: serde_yml::Mapping = serde_yml::from_str(module).unwrap();
-        let name = &module["name"].as_str().unwrap();
-
-        if let Some(protocols) = &module["handles"]["url_protocols"].as_sequence() {
-            for protocol in protocols.iter() {
-                builder
-                    .insert_protocol(name, protocol.as_str().unwrap())
-                    .unwrap();
-            }
+        let module: Manifest = serde_yml::from_str(module).unwrap();
+        for protocol in module.handles.url_protocols {
+            builder.insert_protocol(&module.name, &protocol).unwrap();
         }
 
-        if let Some(prefixes) = &module["handles"]["url_prefixes"].as_sequence() {
-            for prefix in prefixes.iter() {
-                builder
-                    .insert_prefix(name, prefix.as_str().unwrap())
-                    .unwrap()
-            }
+        for prefix in module.handles.url_prefixes {
+            builder.insert_prefix(&module.name, &prefix).unwrap()
         }
 
-        if let Some(patterns) = &module["handles"]["url_patterns"].as_sequence() {
-            for pattern in patterns.iter() {
-                builder
-                    .insert_pattern(name, pattern.as_str().unwrap())
-                    .unwrap()
-            }
+        for pattern in module.handles.url_patterns {
+            builder.insert_pattern(&module.name, &pattern).unwrap()
         }
     }
 

--- a/lib/asimov-module/src/lib.rs
+++ b/lib/asimov-module/src/lib.rs
@@ -21,6 +21,6 @@ pub use tracing;
 #[cfg(feature = "tracing")]
 pub use tracing_subscriber;
 
-pub mod resolve;
-
 pub mod models;
+
+pub mod resolve;

--- a/lib/asimov-module/src/lib.rs
+++ b/lib/asimov-module/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 pub use dogma::prelude;
 
 #[cfg(feature = "cli")]
-pub use clientele::{SysexitsError, SysexitsResult, args_os, dotenv, exit};
+pub use clientele::{args_os, dotenv, exit, SysexitsError, SysexitsResult};
 
 #[cfg(feature = "std")]
 pub use getenv;
@@ -22,3 +22,5 @@ pub use tracing;
 pub use tracing_subscriber;
 
 pub mod resolve;
+
+pub mod models;

--- a/lib/asimov-module/src/models/manifest.rs
+++ b/lib/asimov-module/src/models/manifest.rs
@@ -4,16 +4,16 @@ use alloc::{string::String, vec::Vec};
 
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct Manifest {
+pub struct ModuleManifest {
     pub name: String,
     pub label: String,
     pub summary: String,
     pub links: Vec<String>,
     #[cfg_attr(
         feature = "serde",
-        serde(default, skip_serializing_if = "Flows::is_empty")
+        serde(default, skip_serializing_if = "Provides::is_empty")
     )]
-    pub provides: Flows,
+    pub provides: Provides,
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Handles::is_empty")
@@ -23,13 +23,13 @@ pub struct Manifest {
 
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub struct Flows {
-    pub flows: Vec<String>,
+pub struct Provides {
+    pub programs: Vec<String>,
 }
 
-impl Flows {
+impl Provides {
     pub fn is_empty(&self) -> bool {
-        self.flows.is_empty()
+        self.programs.is_empty()
     }
 }
 

--- a/lib/asimov-module/src/models/manifest.rs
+++ b/lib/asimov-module/src/models/manifest.rs
@@ -1,0 +1,50 @@
+// This is free and unencumbered software released into the public domain.
+
+use alloc::{string::String, vec::Vec};
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+pub struct Manifest {
+    pub name: String,
+    pub label: String,
+    pub summary: String,
+    pub links: Vec<String>,
+    #[serde(default, skip_serializing_if = "Flows::is_empty")]
+    pub provides: Flows,
+    #[serde(default, skip_serializing_if = "Handles::is_empty")]
+    pub handles: Handles,
+}
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+pub struct Flows {
+    pub flows: Vec<String>,
+}
+
+impl Flows {
+    pub fn is_empty(&self) -> bool {
+        self.flows.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+pub struct Handles {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub url_protocols: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub url_prefixes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub url_patterns: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_extensions: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content_types: Vec<String>,
+}
+
+impl Handles {
+    pub fn is_empty(&self) -> bool {
+        self.url_protocols.is_empty()
+            && self.url_prefixes.is_empty()
+            && self.url_patterns.is_empty()
+            && self.file_extensions.is_empty()
+            && self.content_types.is_empty()
+    }
+}

--- a/lib/asimov-module/src/models/manifest.rs
+++ b/lib/asimov-module/src/models/manifest.rs
@@ -2,19 +2,27 @@
 
 use alloc::{string::String, vec::Vec};
 
-#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Manifest {
     pub name: String,
     pub label: String,
     pub summary: String,
     pub links: Vec<String>,
-    #[serde(default, skip_serializing_if = "Flows::is_empty")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Flows::is_empty")
+    )]
     pub provides: Flows,
-    #[serde(default, skip_serializing_if = "Handles::is_empty")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Handles::is_empty")
+    )]
     pub handles: Handles,
 }
 
-#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Flows {
     pub flows: Vec<String>,
 }
@@ -25,17 +33,33 @@ impl Flows {
     }
 }
 
-#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Handles {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Vec::is_empty")
+    )]
     pub url_protocols: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Vec::is_empty")
+    )]
     pub url_prefixes: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Vec::is_empty")
+    )]
     pub url_patterns: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Vec::is_empty")
+    )]
     pub file_extensions: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Vec::is_empty")
+    )]
     pub content_types: Vec<String>,
 }
 

--- a/lib/asimov-module/src/models/mod.rs
+++ b/lib/asimov-module/src/models/mod.rs
@@ -1,0 +1,4 @@
+// This is free and unencumbered software released into the public domain.
+
+mod manifest;
+pub use manifest::*;

--- a/lib/asimov-module/src/resolve.rs
+++ b/lib/asimov-module/src/resolve.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use crate::models::Manifest;
+use crate::models::ModuleManifest;
 use alloc::{
     boxed::Box,
     collections::{btree_map::BTreeMap, btree_set::BTreeSet},
@@ -40,16 +40,16 @@ impl Resolver {
     pub fn try_from_iter<I, T>(iter: I) -> Result<Self, Box<dyn Error>>
     where
         I: Iterator<Item = T>,
-        T: Borrow<Manifest>,
+        T: Borrow<ModuleManifest>,
     {
         ResolverBuilder::try_from_iter(iter)?.build()
     }
 }
 
-impl TryFrom<&[Manifest]> for Resolver {
+impl TryFrom<&[ModuleManifest]> for Resolver {
     type Error = Box<dyn Error>;
 
-    fn try_from(value: &[Manifest]) -> Result<Self, Self::Error> {
+    fn try_from(value: &[ModuleManifest]) -> Result<Self, Self::Error> {
         ResolverBuilder::try_from(value)?.build()
     }
 }
@@ -115,7 +115,7 @@ impl ResolverBuilder {
         Ok(())
     }
 
-    pub fn insert_manifest(&mut self, manifest: &Manifest) -> Result<(), Box<dyn Error>> {
+    pub fn insert_manifest(&mut self, manifest: &ModuleManifest) -> Result<(), Box<dyn Error>> {
         for protocol in &manifest.handles.url_protocols {
             self.insert_protocol(&manifest.name, protocol)?;
         }
@@ -131,7 +131,7 @@ impl ResolverBuilder {
     pub fn try_from_iter<I, T>(mut iter: I) -> Result<Self, Box<dyn Error>>
     where
         I: Iterator<Item = T>,
-        T: Borrow<Manifest>,
+        T: Borrow<ModuleManifest>,
     {
         iter.try_fold(ResolverBuilder::new(), |mut b, m| {
             b.insert_manifest(m.borrow())?;
@@ -148,10 +148,10 @@ impl ResolverBuilder {
     }
 }
 
-impl TryFrom<&[Manifest]> for ResolverBuilder {
+impl TryFrom<&[ModuleManifest]> for ResolverBuilder {
     type Error = Box<dyn Error>;
 
-    fn try_from(value: &[Manifest]) -> Result<Self, Self::Error> {
+    fn try_from(value: &[ModuleManifest]) -> Result<Self, Self::Error> {
         Self::try_from_iter(value.iter())
     }
 }


### PR DESCRIPTION
I believe this is the minimal + most restrictive representation that fits the existing manifests.

Tested with:
```console
$ curl -s -L 'https://github.com/asimov-modules/asimov-apify-module/raw/master/.asimov/module.yaml' | cargo run -q --example decode_manifest
$ curl -s -L 'https://github.com/asimov-modules/asimov-brightdata-module/raw/master/.asimov/module.yaml' | cargo run -q --example decode_manifest
$ curl -s -L 'https://github.com/asimov-modules/asimov-jinja-module/raw/master/.asimov/module.yaml' | cargo run -q --example decode_manifest
$ curl -s -L 'https://github.com/asimov-modules/asimov-near-module/raw/master/.asimov/module.yaml' | cargo run -q --example decode_manifest
$ curl -s -L 'https://github.com/asimov-modules/asimov-nexus-module/raw/master/.asimov/module.yaml' | cargo run -q --example decode_manifest
$ curl -s -L 'https://github.com/asimov-modules/asimov-serpapi-module/raw/master/.asimov/module.yaml' | cargo run -q --example decode_manifest
$ curl -s -L 'https://github.com/asimov-modules/asimov-template-module/raw/master/.asimov/module.yaml' | cargo run -q --example decode_manifest
```

I went with `#[serde(default, skip_serializing_if = "Vec::is_empty")]` + `Vec<T>` over `Option<Vec<T>>` as I think the interface it gives is more pleasant but I'm not opposed to changing it.

Compare:
```rust
let mut builder = ResolverBuilder::new();

let module: Manifest = serde_yml::from_str(module).unwrap();

// with
// Manifest.handles: Handles
// Handles.url_{protocols,prefixes,patterns}: Vec<T>

for protocol in module.handles.url_protocols {
    builder.insert_protocol(&module.name, &protocol).unwrap();
}

// repeat for prefixes
// repeat for patterns
```

```rust
let mut builder = ResolverBuilder::new();

let module: Manifest = serde_yml::from_str(module).unwrap();

// with
// Manifest.handles: Option<Handles>
// Handles.url_{protocols,prefixes,patterns}: Option<Vec<T>>

if let Some(handles) = module.handles {
    for protocol in handles.url_protocols.unwrap_or_default() {
        builder.insert_protocol(&module.name, &protocol).unwrap();
    }
    // repeat for prefixes
    // repeat for patterns
}
```