### PR TITLE
Add support for filetypes in resolver

### DIFF
--- a/lib/asimov-module/Cargo.toml
+++ b/lib/asimov-module/Cargo.toml
@@ -24,6 +24,7 @@ std = [
 	"dogma/std",
 	"getenv?/std",
 	"serde?/std",
+	"slab/std",
 	"tracing?/std",
 	"tracing-subscriber?/fmt",
 	"tracing-subscriber?/std",
@@ -41,10 +42,13 @@ clientele = { workspace = true, features = [
 dogma.workspace = true
 getenv = { workspace = true, optional = true }
 secrecy.workspace = true
-serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0", optional = true, default-features = false, features = [
+	"alloc",
+	"derive",
+] }
+slab = { version = "0.4.10", default-features = false }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
-trie-rs = { version = "0.4", default-features = false }
 url = { version = "2.5", default-features = false }
 
 [dev-dependencies]

--- a/lib/asimov-module/src/lib.rs
+++ b/lib/asimov-module/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 pub use dogma::prelude;
 
 #[cfg(feature = "cli")]
-pub use clientele::{args_os, dotenv, exit, SysexitsError, SysexitsResult};
+pub use clientele::{SysexitsError, SysexitsResult, args_os, dotenv, exit};
 
 #[cfg(feature = "std")]
 pub use getenv;

--- a/lib/asimov-module/src/resolve.rs
+++ b/lib/asimov-module/src/resolve.rs
@@ -257,7 +257,7 @@ impl Sect {
 /// Split and URL into sections that we care about. This is effectively a tokenizer.
 fn split_url(url: &str) -> Result<Vec<Sect>, Box<dyn Error>> {
     if url.is_empty() {
-        return Err("URL can not be empty".into());
+        return Err("URL cannot be empty".into());
     }
 
     let mut res = Vec::new();

--- a/lib/asimov-module/src/resolve.rs
+++ b/lib/asimov-module/src/resolve.rs
@@ -56,7 +56,7 @@ impl Resolver {
         // Process remaining input
         let final_states = input[1..].iter().fold(root_states, |states, sect| {
             if states.is_empty() {
-                return BTreeSet::new();
+                return states;
             }
 
             states

--- a/lib/asimov-module/src/resolve.rs
+++ b/lib/asimov-module/src/resolve.rs
@@ -249,7 +249,7 @@ impl Sect {
 /// Split and URL into sections that we care about. This is effectively a tokenizer.
 fn split_url(url: &str) -> Result<Vec<Sect>, Box<dyn Error>> {
     if url.is_empty() {
-        return Err(format!("URL can not be empty").into());
+        return Err("URL can not be empty".into());
     }
 
     let mut res = Vec::new();
@@ -283,14 +283,12 @@ fn split_url(url: &str) -> Result<Vec<Sect>, Box<dyn Error>> {
 
     if url.cannot_be_a_base() {
         res.push(Sect::Path(url.path().into()))
-    } else {
-        if let Some(path_parts) = url.path_segments() {
-            for part in path_parts {
-                if part.is_empty() {
-                    continue;
-                }
-                res.push(Sect::Path(part.into()));
+    } else if let Some(path_parts) = url.path_segments() {
+        for part in path_parts {
+            if part.is_empty() {
+                continue;
             }
+            res.push(Sect::Path(part.into()));
         }
     }
 


### PR DESCRIPTION
Contains changes:
1. Replaces the external trie lib with a simpler—still a trie-like—[NFA](https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton) approach with benefits: space (common prefixes saved once) and time complexities should be just as good; runtime mutable (no need for `ResolverBuilder` to insert and `ResolverBuilder::build() -> Resolver`); implementation is simpler and much much shorter.
2. Adds support for registering and matching file extensions. Currently this has the interface of `Resolver::insert_file_extension("tar", "tar.gz")` and in `Resolver::resolver("file:///foo/bar/baz.tar.gz")` the extension is all the items to the right of the first dot in the final path section. Possible alternative implementations, if desired, would be matching only the last part (requiring processing one ext at a time), or matching all suffixes starting from the right? (the same as a trie, e.g. first match `["gz"]`, return those modules, then match `["gz", "tar"]`, return those modules, etc.)