### PR TITLE
Add a helper for initializing `tracing` from modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ axum-prometheus = { version = "0.8" }
 bs58 = "0.5"
 bytes = "1.10"
 cfg_aliases = "0.2"
-clientele = { version = "0.3.7", default-features = false }
+clientele = { version = "0.3.8", default-features = false }
 derive_more = { version = "2", default-features = false }
 dogma = { version = "0.1.7", default-features = false, features = ["traits"] }
 futures = "0.3"

--- a/lib/asimov-module/Cargo.toml
+++ b/lib/asimov-module/Cargo.toml
@@ -17,7 +17,7 @@ publish.workspace = true
 [features]
 default = ["all", "cli", "serde", "std"]
 all = ["tracing"]
-cli = ["std", "dep:clientele"]
+cli = ["std", "dep:clientele", "clientele?/clap"]
 std = [
 	"dep:getenv",
 	"clientele?/std",
@@ -30,7 +30,7 @@ std = [
 	"tracing-subscriber?/std",
 	"url/std",
 ]
-tracing = ["dep:tracing", "dep:tracing-subscriber"]
+tracing = ["dep:tracing", "dep:tracing-subscriber", "clientele?/tracing"]
 unstable = []
 
 [dependencies]

--- a/lib/asimov-module/src/lib.rs
+++ b/lib/asimov-module/src/lib.rs
@@ -21,6 +21,21 @@ pub use tracing;
 #[cfg(feature = "tracing")]
 pub use tracing_subscriber;
 
+#[cfg(all(feature = "std", feature = "cli", feature = "tracing"))]
+pub fn init_tracing_subscriber(
+    options: &clientele::StandardOptions,
+) -> Result<(), alloc::boxed::Box<(dyn core::error::Error + Send + Sync + 'static)>> {
+    extern crate std;
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_max_level(options)
+        .with_level(options.debug || options.verbose > 0)
+        .with_target(options.debug)
+        .with_file(false)
+        .without_time()
+        .try_init()
+}
+
 pub mod models;
 
 pub mod resolve;


### PR DESCRIPTION
Used from modules like so:
```rust
#[derive(Parser)]
struct Options {
    #[clap(flatten)]
    flags: StandardOptions,
    // ...
}

// ...
fn main() {
    let args = clientele::args_os().unwrap();
    let options = Options::parse_from(&args);
    asimov_module::init_tracing_subscriber(&options.flags).expect("failed to initialize logging");
}
```

@race-of-sloths