### PR TITLE
Implement CI workflow.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+# See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+---
+name: CI
+
+# WARNING! PLEASE READ BEFORE MAKING ANY CHANGES:
+#
+# This workflow is triggered on `pull_request_target` event,
+# which makes it highly prone to security issues,
+# as in this case we are executing untrusted, user-provided,
+# potentially malicious code from pull requests in an environment
+# that might contain overly permissive tokens or exposed secrets,
+# if not implemented properly.
+#
+# Please only modify this file if you know what you're doing.
+
+on:
+  push:
+    branches: [main, master]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: asimov-platform/actions/.github/workflows/ci-rust.yaml@master
+    secrets: inherit
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write

--- a/lib/asimov-core/src/env.rs
+++ b/lib/asimov-core/src/env.rs
@@ -40,7 +40,7 @@ pub fn config_dir(
             .and_then(|home_dir| home_dir.open_dir(CONFIG_PATH)),
         Ok(path) if path.trim().is_empty() => {
             Err(Error::new(ErrorKind::InvalidData, "ASIMOV_HOME is empty"))
-        }
+        },
         Ok(path) => Dir::create_ambient_dir_all(&path, ambient_authority)
             .and_then(|_| Dir::open_ambient_dir(&path, ambient_authority)),
     }

--- a/lib/asimov-core/src/error.rs
+++ b/lib/asimov-core/src/error.rs
@@ -2,12 +2,12 @@
 
 use alloc::{
     format,
-    string::{FromUtf16Error, FromUtf8Error, String, ToString},
+    string::{FromUtf8Error, FromUtf16Error, String, ToString},
 };
 use asimov_sys::AsiResult;
 use core::{
     convert::TryFrom,
-    ffi::{c_int, FromBytesWithNulError},
+    ffi::{FromBytesWithNulError, c_int},
     fmt,
     num::{ParseFloatError, ParseIntError},
     str::Utf8Error,

--- a/lib/asimov-env/src/envs/python.rs
+++ b/lib/asimov-env/src/envs/python.rs
@@ -147,7 +147,7 @@ impl PythonEnv {
                 let mut command = Command::new(path.join("bin/python3"));
                 command.env("VIRTUAL_ENV", path.as_os_str());
                 command
-            }
+            },
         }
     }
 

--- a/lib/asimov-env/src/envs/ruby.rs
+++ b/lib/asimov-env/src/envs/ruby.rs
@@ -126,7 +126,7 @@ impl RubyEnv {
                 } else {
                     PathBuf::from(ruby().unwrap().as_ref()) // TODO: remove the allocation
                 })
-            }
+            },
         }
     }
 

--- a/lib/asimov-env/src/lib.rs
+++ b/lib/asimov-env/src/lib.rs
@@ -51,7 +51,7 @@ pub fn config_dir() -> std::io::Result<Dir> {
             .and_then(|home_dir| home_dir.open_dir(CONFIG_PATH)),
         Ok(path) if path.trim().is_empty() => {
             Err(Error::new(ErrorKind::InvalidData, "ASIMOV_HOME is empty"))
-        }
+        },
         Ok(path) => Dir::create_ambient_dir_all(&path, ambient_authority)
             .and_then(|_| Dir::open_ambient_dir(&path, ambient_authority)),
     }

--- a/lib/asimov-flow/src/yaml.rs
+++ b/lib/asimov-flow/src/yaml.rs
@@ -5,7 +5,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use asimov_core::{flow::FlowDefinition, MaybeLabeled, MaybeNamed};
+use asimov_core::{MaybeLabeled, MaybeNamed, flow::FlowDefinition};
 use core::str::FromStr;
 
 #[derive(Clone, Debug)]

--- a/lib/asimov-module/src/resolve.rs
+++ b/lib/asimov-module/src/resolve.rs
@@ -175,7 +175,7 @@ impl Resolver {
                     // If the sect is a wildcard domain add a link to self, this will also match multiple subdomains.
                     self.nodes[cur_idx].paths.insert(sect.clone(), cur_idx);
                     cur_idx
-                }
+                },
                 (None, sect) => {
                     // Create a new node
                     let new_node_idx = self.nodes.insert(Node::default());
@@ -183,7 +183,7 @@ impl Resolver {
                     // Add the transition from current node to new node
                     self.nodes[cur_idx].paths.insert(sect.clone(), new_node_idx);
                     new_node_idx
-                }
+                },
             }
         })
     }

--- a/lib/asimov-proxy/src/lib.rs
+++ b/lib/asimov-proxy/src/lib.rs
@@ -2,4 +2,4 @@
 
 #![no_std]
 
-pub use gofer::{open, open_buffered, Error, Result};
+pub use gofer::{Error, Result, open, open_buffered};

--- a/lib/asimov-runner/src/runner.rs
+++ b/lib/asimov-runner/src/runner.rs
@@ -53,7 +53,7 @@ impl Runner {
             Err(err) if err.kind() == ErrorKind::NotFound => {
                 let program = self.0.as_std().get_program().to_owned();
                 return Err(RunnerError::MissingProgram(program));
-            }
+            },
             Err(err) => return Err(RunnerError::SpawnFailure(err)),
         }
     }
@@ -95,7 +95,7 @@ impl fmt::Display for RunnerError {
         match self {
             Self::MissingProgram(program) => {
                 write!(f, "Missing program: {}", program.to_string_lossy())
-            }
+            },
             Self::SpawnFailure(err) => write!(f, "Failed to spawn process: {}", err),
             Self::Failure(error, stderr) => {
                 write!(
@@ -107,7 +107,7 @@ impl fmt::Display for RunnerError {
                     write!(f, "\n{}", stderr)?;
                 }
                 Ok(())
-            }
+            },
             Self::UnexpectedFailure(code, stderr) => {
                 write!(
                     f,
@@ -118,7 +118,7 @@ impl fmt::Display for RunnerError {
                     write!(f, "\n{}", stderr)?;
                 }
                 Ok(())
-            }
+            },
             Self::UnexpectedOther(err) => write!(f, "Unexpected error: {}", err),
         }
     }

--- a/lib/asimov-sdk/src/block.rs
+++ b/lib/asimov-sdk/src/block.rs
@@ -1,16 +1,16 @@
 // This is free and unencumbered software released into the public domain.
 
 use crate::{
+    MaybeLabeled, MaybeNamed,
     flow::{
         BlockDescriptor, ParameterDescriptor, PortDescriptor, PortDirection, PortID, PortState,
     },
-    prelude::{fmt::Debug, null_mut, vec, Cow, String, Vec},
-    MaybeLabeled, MaybeNamed,
+    prelude::{Cow, String, Vec, fmt::Debug, null_mut, vec},
 };
 pub use asimov_core::block::BlockDefinition;
 use asimov_sys::{
-    asiEnumerateBlockParameters, asiEnumerateBlockPorts, AsiBlockDefinition, AsiBlockParameter,
-    AsiBlockPort, AsiInstance, AsiPortDirection, AsiResult,
+    AsiBlockDefinition, AsiBlockParameter, AsiBlockPort, AsiInstance, AsiPortDirection, AsiResult,
+    asiEnumerateBlockParameters, asiEnumerateBlockPorts,
 };
 
 #[derive(Debug)]

--- a/lib/asimov-sdk/src/block_execution.rs
+++ b/lib/asimov-sdk/src/block_execution.rs
@@ -2,8 +2,8 @@
 
 use super::flow::FlowExecutionState;
 use crate::{
-    prelude::{fmt::Debug, Cow, String},
     Named,
+    prelude::{Cow, String, fmt::Debug},
 };
 use asimov_sys::{AsiBlockExecution, AsiFlowExecutionState};
 

--- a/lib/asimov-sdk/src/block_iter.rs
+++ b/lib/asimov-sdk/src/block_iter.rs
@@ -1,10 +1,10 @@
 // This is free and unencumbered software released into the public domain.
 
 use crate::{
-    prelude::{null_mut, vec, Box, Vec},
     BlockDefinition, Error, LocalBlockDefinition, Result,
+    prelude::{Box, Vec, null_mut, vec},
 };
-use asimov_sys::{asiEnumerateBlocks, AsiBlockDefinition, AsiInstance, AsiResult};
+use asimov_sys::{AsiBlockDefinition, AsiInstance, AsiResult, asiEnumerateBlocks};
 
 pub(crate) struct BlockDefinitionIter {
     instance: AsiInstance,

--- a/lib/asimov-sdk/src/block_usage.rs
+++ b/lib/asimov-sdk/src/block_usage.rs
@@ -1,8 +1,8 @@
 // This is free and unencumbered software released into the public domain.
 
 use crate::{
-    prelude::{fmt::Debug, Box, Cow, String},
     BlockDefinition, Named, Result,
+    prelude::{Box, Cow, String, fmt::Debug},
 };
 use asimov_sys::AsiBlockUsage;
 

--- a/lib/asimov-sdk/src/flow/definition.rs
+++ b/lib/asimov-sdk/src/flow/definition.rs
@@ -2,13 +2,13 @@
 
 use super::FlowExecution;
 use crate::{
-    crates::serde,
-    prelude::{fmt::Debug, null_mut, vec, Box, Cow, String, Vec},
     BlockDefinition, BlockUsage, MaybeLabeled, MaybeNamed, Result,
+    crates::serde,
+    prelude::{Box, Cow, String, Vec, fmt::Debug, null_mut, vec},
 };
 use asimov_sys::{
-    asiEnumerateFlowBlocks, asiEnumerateFlowExecutions, AsiBlockDefinition, AsiBlockUsage,
-    AsiFlowDefinition, AsiFlowExecution, AsiInstance, AsiResult,
+    AsiBlockDefinition, AsiBlockUsage, AsiFlowDefinition, AsiFlowExecution, AsiInstance, AsiResult,
+    asiEnumerateFlowBlocks, asiEnumerateFlowExecutions,
 };
 
 #[stability::unstable]

--- a/lib/asimov-sdk/src/flow/definition_iter.rs
+++ b/lib/asimov-sdk/src/flow/definition_iter.rs
@@ -2,10 +2,10 @@
 
 use super::{FlowDefinition, LocalFlowDefinition};
 use crate::{
-    prelude::{null_mut, vec, Box, Vec},
     Error, Result,
+    prelude::{Box, Vec, null_mut, vec},
 };
-use asimov_sys::{asiEnumerateFlows, AsiFlowDefinition, AsiInstance, AsiResult};
+use asimov_sys::{AsiFlowDefinition, AsiInstance, AsiResult, asiEnumerateFlows};
 
 pub(crate) struct FlowDefinitionIter {
     #[allow(unused)]

--- a/lib/asimov-sdk/src/flow/execution.rs
+++ b/lib/asimov-sdk/src/flow/execution.rs
@@ -2,8 +2,8 @@
 
 use super::FlowExecutionState;
 use crate::{
-    prelude::{fmt::Debug, Cow, String},
     Named,
+    prelude::{Cow, String, fmt::Debug},
 };
 use asimov_sys::{AsiFlowExecution, AsiFlowExecutionState};
 

--- a/lib/asimov-sdk/src/initialization.rs
+++ b/lib/asimov-sdk/src/initialization.rs
@@ -1,7 +1,7 @@
 // This is free and unencumbered software released into the public domain.
 
 use crate::Result;
-use asimov_sys::{asiInitLibrary, AsiResult};
+use asimov_sys::{AsiResult, asiInitLibrary};
 
 /// Initializes the SDK library.
 ///

--- a/lib/asimov-sdk/src/instance.rs
+++ b/lib/asimov-sdk/src/instance.rs
@@ -1,18 +1,18 @@
 // This is free and unencumbered software released into the public domain.
 
 use crate::{
-    flow::{FlowDefinition, FlowDefinitionIter, FlowExecution, LocalFlowDefinition},
-    prelude::{format, null, Box, String, Vec},
     BlockDefinition, BlockDefinitionIter, BlockExecution, Error, ModelManifest, ModelManifestIter,
     ModuleRegistration, ModuleRegistrationIter, Result,
+    flow::{FlowDefinition, FlowDefinitionIter, FlowExecution, LocalFlowDefinition},
+    prelude::{Box, String, Vec, format, null},
 };
 use asimov_sys::{
-    asiCloneFlow, asiCreateFlow, asiCreateInstance, asiDestroyInstance, asiDownloadModel,
-    asiEnableModule, asiExecuteBlock, asiExecuteFlow, asiPollFlowExecution, asiRemoveFlow,
-    asiStartFlowExecution, asiStopFlowExecution, asiUpdateFlow, AsiBlockExecuteInfo,
-    AsiBlockExecution, AsiFlowCreateInfo, AsiFlowDefinition, AsiFlowExecuteInfo, AsiFlowExecution,
-    AsiFlowExecutionState, AsiFlowUpdateInfo, AsiInstance, AsiModelDownloadInfo,
-    AsiModuleEnableInfo, AsiResult, AsiStructureHeader, ASI_NULL_HANDLE,
+    ASI_NULL_HANDLE, AsiBlockExecuteInfo, AsiBlockExecution, AsiFlowCreateInfo, AsiFlowDefinition,
+    AsiFlowExecuteInfo, AsiFlowExecution, AsiFlowExecutionState, AsiFlowUpdateInfo, AsiInstance,
+    AsiModelDownloadInfo, AsiModuleEnableInfo, AsiResult, AsiStructureHeader, asiCloneFlow,
+    asiCreateFlow, asiCreateInstance, asiDestroyInstance, asiDownloadModel, asiEnableModule,
+    asiExecuteBlock, asiExecuteFlow, asiPollFlowExecution, asiRemoveFlow, asiStartFlowExecution,
+    asiStopFlowExecution, asiUpdateFlow,
 };
 
 #[derive(Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/lib/asimov-sdk/src/model.rs
+++ b/lib/asimov-sdk/src/model.rs
@@ -1,8 +1,8 @@
 // This is free and unencumbered software released into the public domain.
 
 use crate::{
-    prelude::{fmt::Debug, Cow, String},
     Named,
+    prelude::{Cow, String, fmt::Debug},
 };
 use asimov_sys::AsiModelManifest;
 

--- a/lib/asimov-sdk/src/model_iter.rs
+++ b/lib/asimov-sdk/src/model_iter.rs
@@ -1,10 +1,10 @@
 // This is free and unencumbered software released into the public domain.
 
 use crate::{
-    prelude::{null_mut, vec, Box, Vec},
     Error, LocalModelManifest, ModelManifest, Result,
+    prelude::{Box, Vec, null_mut, vec},
 };
-use asimov_sys::{asiEnumerateModels, AsiInstance, AsiModelManifest, AsiResult};
+use asimov_sys::{AsiInstance, AsiModelManifest, AsiResult, asiEnumerateModels};
 
 pub(crate) struct ModelManifestIter {
     #[allow(unused)]

--- a/lib/asimov-sdk/src/module.rs
+++ b/lib/asimov-sdk/src/module.rs
@@ -1,8 +1,8 @@
 // This is free and unencumbered software released into the public domain.
 
 use crate::{
-    prelude::{fmt::Debug, Cow, Result, String},
     Named,
+    prelude::{Cow, Result, String, fmt::Debug},
 };
 use asimov_sys::{AsiInstance, AsiModuleRegistration};
 

--- a/lib/asimov-sdk/src/module_iter.rs
+++ b/lib/asimov-sdk/src/module_iter.rs
@@ -1,10 +1,10 @@
 // This is free and unencumbered software released into the public domain.
 
 use crate::{
-    prelude::{null_mut, vec, Box, Vec},
     Error, ModuleRegistration, Result, StaticModuleRegistration,
+    prelude::{Box, Vec, null_mut, vec},
 };
-use asimov_sys::{asiEnumerateModules, AsiInstance, AsiModuleRegistration, AsiResult};
+use asimov_sys::{AsiInstance, AsiModuleRegistration, AsiResult, asiEnumerateModules};
 
 pub(crate) struct ModuleRegistrationIter {
     #[allow(unused)]

--- a/lib/asimov-sdk/src/prelude.rs
+++ b/lib/asimov-sdk/src/prelude.rs
@@ -7,7 +7,7 @@ pub use alloc::{
     borrow::Cow,
     boxed::Box,
     format,
-    string::{FromUtf16Error, FromUtf8Error, String, ToString},
+    string::{FromUtf8Error, FromUtf16Error, String, ToString},
     vec,
     vec::Vec,
 };
@@ -15,7 +15,7 @@ pub use alloc::{
 #[allow(unused)]
 pub use core::{
     convert::TryFrom,
-    ffi::{c_int, FromBytesWithNulError},
+    ffi::{FromBytesWithNulError, c_int},
     fmt,
     marker::PhantomData,
     num::{ParseFloatError, ParseIntError},

--- a/lib/asimov-server/examples/mdns-client.rs
+++ b/lib/asimov-server/examples/mdns-client.rs
@@ -9,19 +9,19 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         match event {
             ServiceEvent::SearchStarted(ty) => {
                 println!("Search started for service of type {}", ty);
-            }
+            },
             ServiceEvent::ServiceFound(ty, name) => {
                 println!("Found service of type {} with name {}", ty, name);
-            }
+            },
             ServiceEvent::ServiceResolved(info) => {
                 println!("Resolved service: {:?}", info);
-            }
+            },
             ServiceEvent::ServiceRemoved(ty, name) => {
                 println!("Service of type {} with name {} removed", ty, name);
-            }
+            },
             ServiceEvent::SearchStopped(ty) => {
                 println!("Search stopped for service of type {}", ty);
-            }
+            },
         }
     }
 

--- a/lib/asimov-server/src/http.rs
+++ b/lib/asimov-server/src/http.rs
@@ -12,7 +12,7 @@ mod well_known;
 #[cfg(feature = "app")]
 mod app;
 
-use axum::{response::Json, routing::get, Router};
+use axum::{Router, response::Json, routing::get};
 use tokio::net::{TcpListener, ToSocketAddrs};
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::CorsLayer;

--- a/lib/asimov-server/src/http/mcp.rs
+++ b/lib/asimov-server/src/http/mcp.rs
@@ -1,11 +1,11 @@
 // This is free and unencumbered software released into the public domain.
 
 use axum::{
+    Json, Router,
     extract::State,
-    http::{request::Parts, StatusCode},
+    http::{StatusCode, request::Parts},
     response::{IntoResponse, Response},
     routing::post,
-    Json, Router,
 };
 use rmcp::model::{
     CallToolRequestParam, CallToolResult, ClientJsonRpcMessage, GetPromptRequestParam,
@@ -70,7 +70,7 @@ where
                     }),
                 })
                 .into_response())
-            }
+            },
             PingRequest(_req) => Ok(Json(JsonRpcResponse {
                 jsonrpc: JsonRpcVersion2_0,
                 id: req.id,
@@ -94,7 +94,7 @@ where
                     },
                 })
                 .into_response())
-            }
+            },
             GetPromptRequest(get_req) => {
                 let GetPromptRequestParam { name, arguments } = get_req.params;
 
@@ -111,7 +111,7 @@ where
                     },
                 })
                 .into_response())
-            }
+            },
 
             // Resources
             ListResourcesRequest(list_req) => {
@@ -129,7 +129,7 @@ where
                     },
                 })
                 .into_response())
-            }
+            },
             ListResourceTemplatesRequest(list_req) => {
                 let cursor = list_req.params.and_then(|opt| opt.cursor);
                 let Ok((resource_templates, next_cursor)) =
@@ -147,7 +147,7 @@ where
                     },
                 })
                 .into_response())
-            }
+            },
             ReadResourceRequest(read_req) => {
                 let uri = read_req.params.uri;
 
@@ -161,7 +161,7 @@ where
                     result: ReadResourceResult { contents },
                 })
                 .into_response())
-            }
+            },
 
             // Tools
             ListToolsRequest(list_req) => {
@@ -176,7 +176,7 @@ where
                     result: ListToolsResult { tools, next_cursor },
                 })
                 .into_response())
-            }
+            },
             CallToolRequest(call_req) => {
                 let CallToolRequestParam { name, arguments } = call_req.params;
 
@@ -190,7 +190,7 @@ where
                     result: CallToolResult { content, is_error },
                 })
                 .into_response())
-            }
+            },
 
             CompleteRequest(_)
             | SetLevelRequest(_)

--- a/lib/asimov-server/tests/mcp.rs
+++ b/lib/asimov-server/tests/mcp.rs
@@ -1,7 +1,7 @@
 // This is free and unencumbered software released into the public domain.
 
 use asimov_server::http::mcp::Tool;
-use axum::{http::StatusCode, Router};
+use axum::{Router, http::StatusCode};
 use axum_test::TestServer;
 use rmcp::model::{
     CallToolRequest, CallToolRequestMethod, CallToolRequestParam, CallToolResult, Content,

--- a/lib/asimov-sys/Cargo.toml
+++ b/lib/asimov-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "asimov-sys"
 version.workspace = true
 authors.workspace = true
-edition.workspace = true
+edition = "2021"
 rust-version.workspace = true
 description.workspace = true
 #documentation.workspace = true


### PR DESCRIPTION
This PR implements a shared CI workflow and fixes multiple things that makes it fail.
- Formatting issues were fixed by running `cargo fmt -all`.
- `asimov-sys` bindgen generates `extern "C"` blocks **without** `unsafe` keyword, which is required in 2024 Rust edition. Thus Rust edition for `asimov-sys` was lowered to 2021.

I wasn't sure if we are okay with these changes, thus PR instead of pushing to master.

@race-of-sloths include!