### PR TITLE
Fix getting `asimov_root` on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ getenv = { version = "0.1.2", default-features = false, features = [
     "posix",
     "python",
     "ruby",
+    "windows",
 ] }
 gofer = { version = "0.1.8", default-features = false, features = [
     "all",

--- a/lib/asimov-env/src/paths.rs
+++ b/lib/asimov-env/src/paths.rs
@@ -4,9 +4,19 @@ use super::vars;
 use std::path::PathBuf;
 
 pub fn asimov_root() -> PathBuf {
-    vars::asimov_root()
-        .or_else(|| getenv::home().map(|p| PathBuf::from(p).join(".asimov")))
-        .expect("ASIMOV_ROOT or HOME environment variable must be set")
+    if let Some(asimov_root) = vars::asimov_root() {
+        return asimov_root;
+    }
+
+    #[cfg(unix)]
+    return getenv::home()
+        .map(|p| PathBuf::from(p).join(".asimov"))
+        .expect("ASIMOV_ROOT or HOME environment variables must be set");
+
+    #[cfg(windows)]
+    return getenv::appdata()
+        .map(|p| PathBuf::from(p).join("ASIMOV"))
+        .expect("ASIMOV_ROOT or APPDATA environment variables must be set");
 }
 
 pub fn python_env() -> PathBuf {


### PR DESCRIPTION
Fixes `asimov_env::paths::asimov_root()` on Windows to return idiomatic path, which is `%APPDATA%/ASIMOV`.