### PR TITLE
Samuel/module config

### DIFF
--- a/lib/asimov-module/Cargo.toml
+++ b/lib/asimov-module/Cargo.toml
@@ -19,7 +19,9 @@ default = ["all", "cli", "serde", "std"]
 all = ["tracing"]
 cli = ["std", "dep:clientele", "clientele?/clap"]
 std = [
+	"dep:asimov-env",
 	"dep:getenv",
+	"dep:serde_yml",
 	"clientele?/std",
 	"dogma/std",
 	"getenv?/std",
@@ -34,6 +36,7 @@ tracing = ["dep:tracing", "dep:tracing-subscriber", "clientele?/tracing"]
 unstable = []
 
 [dependencies]
+asimov-env = { workspace = true, optional = true }
 clientele = { workspace = true, features = [
 	"argfile",
 	"dotenv",
@@ -50,6 +53,4 @@ slab = { version = "0.4.10", default-features = false }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 url = { version = "2.5", default-features = false }
-
-[dev-dependencies]
-serde_yml = { version = "0.0.12", default-features = false }
+serde_yml = { version = "0.0.12", default-features = false, optional = true }

--- a/lib/asimov-module/examples/config.rs
+++ b/lib/asimov-module/examples/config.rs
@@ -1,0 +1,40 @@
+// This is free and unencumbered software released into the public domain.
+
+use asimov_module::models::ModuleManifest;
+use std::error::Error;
+
+const YAML: &str = r#"
+name: brightdata
+label: Bright Data
+summary: Data import powered by the Bright Data web data platform.
+links:
+    - https://github.com/asimov-modules/asimov-brightdata-module
+    - https://crates.io/crates/asimov-brightdata-module
+    - https://pypi.org/project/asimov-brightdata-module
+    - https://rubygems.org/gems/asimov-brightdata-module
+    - https://npmjs.com/package/asimov-brightdata-module
+
+config:
+  variables:
+    - name: API_KEY
+      description: "API Key to authorize requests to Bright Data"
+
+    - name: OTHER_VAR
+      default_value: "foobar"
+"#;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let manifest: ModuleManifest = serde_yml::from_str(YAML)?;
+
+    let api_key = manifest
+        .variable("API_KEY", None)
+        .or_else(|_err| std::env::var("BRIGHTDATA_API_KEY"))
+        .inspect_err(|_err| eprintln!("No API_KEY found. Either configure API_KEY with `asimov module config brightdata API_KEY <your_api-key>` or set the environment variable `BRIGHTDATA_API_KEY`"))
+        .unwrap_or_default();
+    println!("API_KEY: `{api_key}`");
+
+    let other_var = manifest.variable("OTHER_VAR", None).unwrap_or_default();
+    println!("OTHER_VAR: `{other_var}`");
+
+    Ok(())
+}

--- a/lib/asimov-module/src/lib.rs
+++ b/lib/asimov-module/src/lib.rs
@@ -5,10 +5,13 @@
 
 extern crate alloc;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 pub use dogma::prelude;
 
 #[cfg(feature = "cli")]
-pub use clientele::{SysexitsError, SysexitsResult, args_os, dotenv, exit};
+pub use clientele::{args_os, dotenv, exit, SysexitsError, SysexitsResult};
 
 #[cfg(feature = "std")]
 pub use getenv;

--- a/lib/asimov-module/src/models/manifest.rs
+++ b/lib/asimov-module/src/models/manifest.rs
@@ -9,16 +9,24 @@ pub struct ModuleManifest {
     pub label: String,
     pub summary: String,
     pub links: Vec<String>,
+
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Provides::is_empty")
     )]
     pub provides: Provides,
+
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Handles::is_empty")
     )]
     pub handles: Handles,
+
+    #[cfg_attr(
+        feature = "serde",
+        serde(alias = "configuration", skip_serializing_if = "Option::is_none")
+    )]
+    pub config: Option<Configuration>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -41,21 +49,25 @@ pub struct Handles {
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub url_protocols: Vec<String>,
+
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub url_prefixes: Vec<String>,
+
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub url_patterns: Vec<String>,
+
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
     )]
     pub file_extensions: Vec<String>,
+
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Vec::is_empty")
@@ -71,4 +83,32 @@ impl Handles {
             && self.file_extensions.is_empty()
             && self.content_types.is_empty()
     }
+}
+
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct Configuration {
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Vec::is_empty")
+    )]
+    pub variables: Vec<ConfigurationVariable>,
+}
+
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct ConfigurationVariable {
+    pub name: String,
+
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, alias = "desc", skip_serializing_if = "Option::is_none")
+    )]
+    pub description: Option<String>,
+
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, alias = "default", skip_serializing_if = "Option::is_none")
+    )]
+    pub default_value: Option<String>,
 }


### PR DESCRIPTION
- Adds an optional section to the module manifest that matches this format:

```yaml
config:
  variables:
    - name: API_KEY
      # optional `description` or `desc` field:
      description: "API Key to authorize requests"

    - name: OTHER_VAR
      # optional `default_value` or `default` field:
      default_value: "foobar"
```

- Adds helpers for reading a manifest and getting config variables


@race-of-sloths