### PR TITLE
Add read methods to snapshotter

### DIFF
--- a/lib/asimov-snapshot/src/snapshot.rs
+++ b/lib/asimov-snapshot/src/snapshot.rs
@@ -28,24 +28,35 @@ impl<S> Snapshotter<S> {
 }
 
 impl<S: crate::storage::Storage> Snapshotter<S> {
-    #[tracing::instrument(skip(self))]
-    pub async fn snapshot(&mut self, url: &str) -> Result<()> {
+    #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
+    pub async fn snapshot(&mut self, url: impl AsRef<str>) -> Result<()> {
         let module = self
             .resolver
-            .resolve(url)
+            .resolve(url.as_ref())
             .map_err(std::io::Error::other)?
             .first()
             .cloned()
             .ok_or_else(|| std::io::Error::other("No module found for fetch operation"))?;
         let timestamp = Timestamp::now();
         let program = std::format!("asimov-{}-fetcher", module.name);
-        let options = FetcherOptions::builder().output("jsonld").build();
-        let data = asimov_runner::Fetcher::new(program, url, GraphOutput::Captured, options)
-            .execute()
-            .await
-            .map_err(|e| std::io::Error::other(std::format!("Execution error: {e}")))?;
+        let options = FetcherOptions::builder().build();
+        let data =
+            asimov_runner::Fetcher::new(program, url.as_ref(), GraphOutput::Captured, options)
+                .execute()
+                .await
+                .map_err(|e| std::io::Error::other(std::format!("Execution error: {e}")))?;
 
         self.storage.save(url, timestamp, data.get_ref())
+    }
+
+    #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
+    pub async fn read(&self, url: impl AsRef<str>, timestamp: Timestamp) -> Result<Vec<u8>> {
+        self.storage.read(url, timestamp)
+    }
+
+    #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
+    pub async fn read_current(&self, url: impl AsRef<str>) -> Result<Vec<u8>> {
+        self.storage.read_current(url)
     }
 
     #[tracing::instrument(skip(self))]
@@ -58,16 +69,16 @@ impl<S: crate::storage::Storage> Snapshotter<S> {
         self.storage.list_snapshots(url)
     }
 
-    #[tracing::instrument(skip(self))]
-    pub async fn compact(&self, url: &str) -> Result<()> {
+    #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
+    pub async fn compact(&self, url: impl AsRef<str>) -> Result<()> {
         // TODO: max hourly/daily/weekly/monthly/yearly snapshots
-        let timestamps = self.storage.list_snapshots(url)?;
+        let timestamps = self.storage.list_snapshots(&url)?;
         let Some(latest) = timestamps.iter().max() else {
             return Ok(());
         };
         tracing::debug!("Deleting snapshots older than `{latest}`");
         for &ts in timestamps.iter().filter(|&ts| ts != latest) {
-            self.storage.delete(url, ts)?;
+            self.storage.delete(&url, ts)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Tiny patch to forward the `read` and `read_current` methods from the storage.

@race-of-sloths