### PR TITLE
Support libexec path in asimov-runner

### DIFF
--- a/lib/asimov-installer/src/installer/error.rs
+++ b/lib/asimov-installer/src/installer/error.rs
@@ -28,7 +28,7 @@ pub enum InstalledModulesError {
 
 #[derive(Debug, Error)]
 pub enum EnabledModulesError {
-    #[error("failed to create directory for enabled modules `{0}`: {1}")]
+    #[error("failed to read directory for enabled modules `{0}`: {1}")]
     DirIo(PathBuf, #[source] io::Error),
     #[error("failed to read symlink for enabled module at `{0}`: {1}")]
     LinkIo(PathBuf, #[source] io::Error),

--- a/lib/asimov-runner/Cargo.toml
+++ b/lib/asimov-runner/Cargo.toml
@@ -22,6 +22,7 @@ tracing = ["dep:tracing"]
 unstable = []
 
 [dependencies]
+asimov-env.workspace = true
 asimov-patterns.workspace = true
 asimov-prompt.workspace = true
 async-trait.workspace = true

--- a/lib/asimov-runner/src/executor.rs
+++ b/lib/asimov-runner/src/executor.rs
@@ -13,7 +13,16 @@ pub struct Executor(Command);
 
 impl Executor {
     pub fn new(program: impl AsRef<OsStr>) -> Self {
-        let mut command = Command::new(program);
+        let libexec_path = asimov_env::paths::asimov_root()
+            .join("libexec")
+            .join(program.as_ref());
+
+        let mut command = if libexec_path.exists() {
+            Command::new(libexec_path)
+        } else {
+            Command::new(program)
+        };
+
         command.env("NO_COLOR", "1"); // See: https://no-color.org
         command.stdin(Stdio::null());
         command.stdout(Stdio::null());

--- a/lib/asimov-snapshot/src/snapshot.rs
+++ b/lib/asimov-snapshot/src/snapshot.rs
@@ -17,14 +17,6 @@ impl<S> Snapshotter<S> {
     pub fn new(resolver: Resolver, storage: S) -> Self {
         Self { resolver, storage }
     }
-
-    pub fn new_fs() -> Result<Snapshotter<crate::storage::Fs>> {
-        let snapshot_dir = asimov_root().join("snapshots");
-        let storage = crate::storage::Fs::for_dir(snapshot_dir)?;
-        let manifest_dir = asimov_root().join("modules");
-        let resolver = Resolver::try_from_dir(manifest_dir).map_err(std::io::Error::other)?;
-        Ok(Snapshotter { resolver, storage })
-    }
 }
 
 impl<S: crate::storage::Storage> Snapshotter<S> {


### PR DESCRIPTION
Adds support for running binaries from installed modules without modifications to env (e.g. `$PATH`).
Tested to work with [`asimov-snapshot-cli`](https://github.com/asimov-platform/asimov-snapshot-cli).

@race-of-sloths