### PR TITLE
Update `read_manifest` helper

### DIFF
--- a/lib/asimov-snapshot/src/snapshot.rs
+++ b/lib/asimov-snapshot/src/snapshot.rs
@@ -1,6 +1,5 @@
 // This is free and unencumbered software released into the public domain.
 
-use asimov_env::paths::asimov_root;
 use asimov_module::resolve::Resolver;
 use asimov_runner::{FetcherOptions, GraphOutput};
 use jiff::Timestamp;


### PR DESCRIPTION
Updates the `read_manifest` helper to match the new `asimov_installer` implementation.

The helper is/may be used by:
1. modules to read their own manifest and/or config
2. currently asimov-cli but I'm updating that

@race-of-sloths