### PR TITLE
Implement time-to-live options for snapshots

### DIFF
--- a/lib/asimov-snapshot/Cargo.toml
+++ b/lib/asimov-snapshot/Cargo.toml
@@ -28,6 +28,7 @@ asimov-module.workspace = true
 asimov-patterns.workspace = true
 asimov-runner.workspace = true
 async-trait.workspace = true
+bon.workspace = true
 dogma.workspace = true
 jiff.workspace = true
 tracing = { workspace = true, features = ["attributes"] }

--- a/lib/asimov-snapshot/src/snapshot.rs
+++ b/lib/asimov-snapshot/src/snapshot.rs
@@ -2,23 +2,37 @@
 
 use asimov_module::resolve::Resolver;
 use asimov_runner::{FetcherOptions, GraphOutput};
-use jiff::Timestamp;
+use jiff::{Span, Timestamp};
 use std::{io::Result, string::String, vec::Vec};
+
+#[derive(Clone, Debug, Default, bon::Builder)]
+pub struct Options {
+    /// max_current_age controls maximum age of the "current" snapshot that is
+    /// allowed to be returned from `Snapshotter.read_current`.
+    #[builder(with = |duration: std::time::Duration| -> core::result::Result<_, jiff::Error> { Span::try_from(duration) })]
+    pub max_current_age: Option<Span>,
+}
 
 pub struct Snapshotter<S> {
     // TODO: not critical but would be nice to have the ability to inject the fetcher impl:
     // fetcher: F,
     resolver: Resolver,
     storage: S,
+    options: Options,
 }
 
 impl<S> Snapshotter<S> {
-    pub fn new(resolver: Resolver, storage: S) -> Self {
-        Self { resolver, storage }
+    pub fn new(resolver: Resolver, storage: S, options: Options) -> Self {
+        Self {
+            resolver,
+            storage,
+            options,
+        }
     }
 }
 
 impl<S: crate::storage::Storage> Snapshotter<S> {
+    /// snapshot fetches the content from an URL and saves it to the snapshot storage.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
     pub async fn snapshot(&mut self, url: impl AsRef<str>) -> Result<()> {
         let module = self
@@ -40,26 +54,64 @@ impl<S: crate::storage::Storage> Snapshotter<S> {
         self.storage.save(url, timestamp, data.get_ref())
     }
 
+    /// read returns the snapshot content of an URL at the given timestamp.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
     pub async fn read(&self, url: impl AsRef<str>, timestamp: Timestamp) -> Result<Vec<u8>> {
         self.storage.read(url, timestamp)
     }
 
+    /// read_current returns the latest snapshot content of an URL.
+    ///
+    /// A fresh snapshot is first created if [`Options::max_current_age`]
+    /// is set and the latest snapshot is older than the maximum age.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
-    pub async fn read_current(&self, url: impl AsRef<str>) -> Result<Vec<u8>> {
+    pub async fn read_current(&mut self, url: impl AsRef<str>) -> Result<Vec<u8>> {
+        if let Some(max_age) = &self.options.max_current_age {
+            let ts = self
+                .storage
+                .current_version(&url)?
+                .to_zoned(jiff::tz::TimeZone::UTC);
+            let now = jiff::Zoned::now();
+
+            let diff = &now - &ts;
+
+            // should never error, we provide `(jiff::Span, &jiff::Zoned)` to `compare`.
+            // doc:
+            // > If either of the spans being compared have a non-zero calendar
+            // > unit (units bigger than hours), then this routine requires a
+            // > relative datetime. If one is not provided, then an error is
+            // > returned.
+            match diff.compare((max_age, &now)) {
+                Ok(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal) => {
+                    tracing::debug!("Updating current snapshot...");
+                    self.snapshot(&url).await?
+                },
+                Ok(std::cmp::Ordering::Less) => (),
+                Err(err) => {
+                    tracing::error!(?err, "unable to compare timestamps, not updating snapshot")
+                },
+            };
+        };
+
         self.storage.read_current(url)
     }
 
+    /// list returns the list of snapshotted URLs along with their latest timestamps.
+    /// Entries can be read by [`Self::read`].
     #[tracing::instrument(skip(self))]
     pub async fn list(&self) -> Result<Vec<(String, Timestamp)>> {
         self.storage.list_urls()
     }
 
+    /// log returns the log of timestamps for a given URL.
+    /// Entries can be read by [`Self::read`].
     #[tracing::instrument(skip(self))]
     pub async fn log(&self, url: &str) -> Result<Vec<Timestamp>> {
         self.storage.list_snapshots(url)
     }
 
+    /// compact deletes old snapshots for a given URL.
+    /// Currently everything but the latest snasphot is deleted.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
     pub async fn compact(&self, url: impl AsRef<str>) -> Result<()> {
         // TODO: max hourly/daily/weekly/monthly/yearly snapshots

--- a/lib/asimov-snapshot/src/snapshot.rs
+++ b/lib/asimov-snapshot/src/snapshot.rs
@@ -7,8 +7,8 @@ use std::{io::Result, string::String, vec::Vec};
 
 #[derive(Clone, Debug, Default, bon::Builder)]
 pub struct Options {
-    /// max_current_age controls maximum age of the "current" snapshot that is
-    /// allowed to be returned from `Snapshotter.read_current`.
+    /// Controls maximum age of the "current" snapshot that is allowed to be
+    /// returned from `Snapshotter.read_current`.
     #[builder(with = |duration: std::time::Duration| -> core::result::Result<_, jiff::Error> { Span::try_from(duration) })]
     pub max_current_age: Option<Span>,
 }
@@ -32,7 +32,7 @@ impl<S> Snapshotter<S> {
 }
 
 impl<S: crate::storage::Storage> Snapshotter<S> {
-    /// snapshot fetches the content from an URL and saves it to the snapshot storage.
+    /// Fetches the content from an URL and saves it to the snapshot storage.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
     pub async fn snapshot(&mut self, url: impl AsRef<str>) -> Result<()> {
         let module = self
@@ -54,13 +54,13 @@ impl<S: crate::storage::Storage> Snapshotter<S> {
         self.storage.save(url, timestamp, data.get_ref())
     }
 
-    /// read returns the snapshot content of an URL at the given timestamp.
+    /// Returns the snapshot content of an URL at the given timestamp.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
     pub async fn read(&self, url: impl AsRef<str>, timestamp: Timestamp) -> Result<Vec<u8>> {
         self.storage.read(url, timestamp)
     }
 
-    /// read_current returns the latest snapshot content of an URL.
+    /// Returns the latest snapshot content of an URL.
     ///
     /// A fresh snapshot is first created if [`Options::max_current_age`]
     /// is set and the latest snapshot is older than the maximum age.
@@ -96,21 +96,21 @@ impl<S: crate::storage::Storage> Snapshotter<S> {
         self.storage.read_current(url)
     }
 
-    /// list returns the list of snapshotted URLs along with their latest timestamps.
+    /// Returns the list of snapshotted URLs along with their latest timestamps.
     /// Entries can be read by [`Self::read`].
     #[tracing::instrument(skip(self))]
     pub async fn list(&self) -> Result<Vec<(String, Timestamp)>> {
         self.storage.list_urls()
     }
 
-    /// log returns the log of timestamps for a given URL.
+    /// Returns the log of timestamps for a given URL.
     /// Entries can be read by [`Self::read`].
     #[tracing::instrument(skip(self))]
     pub async fn log(&self, url: &str) -> Result<Vec<Timestamp>> {
         self.storage.list_snapshots(url)
     }
 
-    /// compact deletes old snapshots for a given URL.
+    /// Deletes old snapshots for a given URL.
     /// Currently everything but the latest snapshot is deleted.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
     pub async fn compact(&self, url: impl AsRef<str>) -> Result<()> {

--- a/lib/asimov-snapshot/src/snapshot.rs
+++ b/lib/asimov-snapshot/src/snapshot.rs
@@ -2,15 +2,24 @@
 
 use asimov_module::resolve::Resolver;
 use asimov_runner::{FetcherOptions, GraphOutput};
-use jiff::{Span, Timestamp};
+use jiff::{Span, Timestamp, ToSpan};
 use std::{io::Result, string::String, vec::Vec};
 
-#[derive(Clone, Debug, Default, bon::Builder)]
+#[derive(Clone, Debug, bon::Builder)]
 pub struct Options {
     /// Controls maximum age of the "current" snapshot that is allowed to be
     /// returned from `Snapshotter.read_current`.
-    #[builder(with = |duration: std::time::Duration| -> core::result::Result<_, jiff::Error> { Span::try_from(duration) })]
+    #[builder(required, default = Some(1.minute()))]
+    #[builder(with = |duration: std::time::Duration| -> core::result::Result<_, jiff::Error> { Span::try_from(duration).map(Option::Some) })]
     pub max_current_age: Option<Span>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            max_current_age: Some(1.minute()),
+        }
+    }
 }
 
 pub struct Snapshotter<S> {

--- a/lib/asimov-snapshot/src/snapshot.rs
+++ b/lib/asimov-snapshot/src/snapshot.rs
@@ -111,7 +111,7 @@ impl<S: crate::storage::Storage> Snapshotter<S> {
     }
 
     /// compact deletes old snapshots for a given URL.
-    /// Currently everything but the latest snasphot is deleted.
+    /// Currently everything but the latest snapshot is deleted.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
     pub async fn compact(&self, url: impl AsRef<str>) -> Result<()> {
         // TODO: max hourly/daily/weekly/monthly/yearly snapshots


### PR DESCRIPTION
- Adds option for controlling staleness of `Snapshotter::read_current`, if the current snapshot is older than the setting a fresh snapshot is fetched first.
- Adds docs to `Snapshotter`'s methods

Should we set the default `max_current_age` to something?

@race-of-sloths
