### PR TITLE
Update snapshot implementation

### DIFF
--- a/lib/asimov-snapshot/Cargo.toml
+++ b/lib/asimov-snapshot/Cargo.toml
@@ -26,6 +26,7 @@ unstable = []
 asimov-env.workspace = true
 asimov-module.workspace = true
 asimov-patterns.workspace = true
+asimov-registry.workspace = true
 asimov-runner.workspace = true
 async-trait.workspace = true
 bon.workspace = true

--- a/lib/asimov-snapshot/Cargo.toml
+++ b/lib/asimov-snapshot/Cargo.toml
@@ -18,7 +18,7 @@ publish.workspace = true
 default = ["all", "std"]
 all = ["tracing", "storage-fs"]
 std = ["dogma/std", "hex/std", "jiff/std", "tracing/std"]
-storage-fs = ["dep:cap-std", "dep:hex", "dep:sha2", "std"]
+storage-fs = ["dep:cap-std", "dep:cap-tempfile", "dep:hex", "dep:sha2", "std"]
 tracing = []
 unstable = []
 
@@ -35,6 +35,7 @@ tracing = { workspace = true, features = ["attributes"] }
 
 # Optional dependencies:
 cap-std = { workspace = true, optional = true }
+cap-tempfile = { version = "3.4", optional = true }
 hex = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 

--- a/lib/asimov-snapshot/src/lib.rs
+++ b/lib/asimov-snapshot/src/lib.rs
@@ -13,7 +13,7 @@ pub use snapshot::*;
 #[cfg(feature = "std")]
 pub mod storage;
 
-#[derive(Clone, Debug, bon::Builder)]
+#[derive(Clone, Debug, PartialEq, Eq, bon::Builder)]
 pub struct Snapshot {
     #[builder(into)]
     pub url: std::string::String,

--- a/lib/asimov-snapshot/src/lib.rs
+++ b/lib/asimov-snapshot/src/lib.rs
@@ -12,13 +12,3 @@ pub use snapshot::*;
 
 #[cfg(feature = "std")]
 pub mod storage;
-
-#[derive(Clone, Debug, PartialEq, Eq, bon::Builder)]
-pub struct Snapshot {
-    #[builder(into)]
-    pub url: std::string::String,
-    #[builder(into)]
-    pub data: std::vec::Vec<u8>,
-    pub start_timestamp: jiff::Timestamp,
-    pub end_timestamp: Option<jiff::Timestamp>,
-}

--- a/lib/asimov-snapshot/src/lib.rs
+++ b/lib/asimov-snapshot/src/lib.rs
@@ -12,3 +12,13 @@ pub use snapshot::*;
 
 #[cfg(feature = "std")]
 pub mod storage;
+
+#[derive(Clone, Debug, bon::Builder)]
+pub struct Snapshot {
+    #[builder(into)]
+    pub url: std::string::String,
+    #[builder(into)]
+    pub data: std::vec::Vec<u8>,
+    pub start_timestamp: jiff::Timestamp,
+    pub end_timestamp: Option<jiff::Timestamp>,
+}

--- a/lib/asimov-snapshot/src/snapshot.rs
+++ b/lib/asimov-snapshot/src/snapshot.rs
@@ -77,7 +77,7 @@ impl<S: crate::storage::Storage> Snapshotter<S> {
 
     /// Returns the snapshot content of an URL at the given timestamp.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
-    pub async fn read(&self, url: impl AsRef<str>, timestamp: Timestamp) -> Result<Vec<u8>> {
+    pub async fn read(&self, url: impl AsRef<str>, timestamp: Timestamp) -> Result<Snapshot> {
         self.storage.read(url, timestamp)
     }
 
@@ -86,7 +86,7 @@ impl<S: crate::storage::Storage> Snapshotter<S> {
     /// A fresh snapshot is first created if [`Options::max_current_age`]
     /// is set and the latest snapshot is older than the maximum age.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
-    pub async fn read_current(&mut self, url: impl AsRef<str>) -> Result<Vec<u8>> {
+    pub async fn read_current(&mut self, url: impl AsRef<str>) -> Result<Snapshot> {
         if let Some(max_age) = &self.options.max_current_age {
             let ts = self
                 .storage

--- a/lib/asimov-snapshot/src/snapshot.rs
+++ b/lib/asimov-snapshot/src/snapshot.rs
@@ -1,9 +1,14 @@
 // This is free and unencumbered software released into the public domain.
 
 use asimov_module::resolve::Resolver;
-use asimov_runner::{FetcherOptions, GraphOutput};
+use asimov_registry::Registry;
+use asimov_runner::GraphOutput;
 use jiff::{Span, Timestamp, ToSpan};
-use std::{io::Result, string::String, vec::Vec};
+use std::{
+    io::{self, Result},
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use crate::Snapshot;
 
@@ -27,17 +32,20 @@ impl Default for Options {
 pub struct Snapshotter<S> {
     // TODO: not critical but would be nice to have the ability to inject the fetcher impl:
     // fetcher: F,
-    resolver: Resolver,
+    registry: Registry,
     storage: S,
     options: Options,
+
+    cached_resolver: Option<Resolver>,
 }
 
 impl<S> Snapshotter<S> {
-    pub fn new(resolver: Resolver, storage: S, options: Options) -> Self {
+    pub fn new(registry: Registry, storage: S, options: Options) -> Self {
         Self {
-            resolver,
+            registry,
             storage,
             options,
+            cached_resolver: None,
         }
     }
 }
@@ -45,34 +53,75 @@ impl<S> Snapshotter<S> {
 impl<S: crate::storage::Storage> Snapshotter<S> {
     /// Fetches the content from an URL and saves it to the snapshot storage.
     #[tracing::instrument(skip(self), fields(url = url.as_ref()))]
-    pub async fn snapshot(&mut self, url: impl AsRef<str>) -> Result<()> {
-        let module = self
-            .resolver
+    pub async fn snapshot(&mut self, url: impl AsRef<str>) -> Result<Snapshot> {
+        if self.cached_resolver.is_none() {
+            let modules = self
+                .registry
+                .enabled_modules()
+                .await
+                .map_err(io::Error::other)?
+                .into_iter()
+                .map(|enabled| enabled.manifest)
+                .filter(|manifest| {
+                    manifest
+                        .provides
+                        .programs
+                        .iter()
+                        .any(|p| p.ends_with("-fetcher") || p.ends_with("-cataloger"))
+                });
+            let resolver = Resolver::try_from_iter(modules).map_err(io::Error::other)?;
+            self.cached_resolver = Some(resolver);
+        }
+        let resolver = self.cached_resolver.as_ref().unwrap();
+
+        let module = resolver
             .resolve(url.as_ref())
             .map_err(std::io::Error::other)?
             .first()
             .cloned()
-            .ok_or_else(|| std::io::Error::other("No module found for fetch operation"))?;
+            .ok_or_else(|| std::io::Error::other("No module found for creating snapshot"))?;
+
+        let programs = self
+            .registry
+            .read_manifest(&module.name)
+            .await
+            .map_err(io::Error::other)?
+            .manifest
+            .provides
+            .programs;
+
+        let url = url.as_ref().to_string();
+
         let start_timestamp = Timestamp::now();
-        let program = std::format!("asimov-{}-fetcher", module.name);
-        let options = FetcherOptions::builder().build();
-        let data =
-            asimov_runner::Fetcher::new(program, url.as_ref(), GraphOutput::Captured, options)
+
+        let data = if let Some(program) = programs.iter().find(|p| p.ends_with("-fetcher")) {
+            asimov_runner::Fetcher::new(program, &url, GraphOutput::Captured, Default::default())
                 .execute()
                 .await
-                .map_err(|e| std::io::Error::other(std::format!("Execution error: {e}")))?
-                .into_inner(); // TODO: consider using the std::io::Cursor?
+        } else if let Some(program) = programs.iter().find(|p| p.ends_with("-cataloger")) {
+            asimov_runner::Cataloger::new(program, &url, GraphOutput::Captured, Default::default())
+                .execute()
+                .await
+        } else {
+            return Err(std::io::Error::other(
+                "No module found for creating snapshot",
+            ));
+        }
+        .map_err(|e| std::io::Error::other(std::format!("Execution error: {e}")))?
+        .into_inner(); // TODO: consider using the std::io::Cursor?
 
         let end_timestamp = Some(Timestamp::now());
 
         let snapshot = Snapshot {
-            url: url.as_ref().into(),
+            url,
             start_timestamp,
             end_timestamp,
             data,
         };
 
-        self.storage.save(&snapshot)
+        self.storage.save(&snapshot)?;
+
+        Ok(snapshot)
     }
 
     /// Returns the snapshot content of an URL at the given timestamp.
@@ -105,9 +154,9 @@ impl<S: crate::storage::Storage> Snapshotter<S> {
             match diff.compare((max_age, &now)) {
                 Ok(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal) => {
                     tracing::debug!("Updating current snapshot...");
-                    self.snapshot(&url).await?
+                    return self.snapshot(&url).await;
                 },
-                Ok(std::cmp::Ordering::Less) => (),
+                Ok(std::cmp::Ordering::Less) => return self.storage.read_current(url),
                 Err(err) => {
                     tracing::error!(?err, "unable to compare timestamps, not updating snapshot")
                 },

--- a/lib/asimov-snapshot/src/snapshot.rs
+++ b/lib/asimov-snapshot/src/snapshot.rs
@@ -10,7 +10,15 @@ use std::{
     vec::Vec,
 };
 
-use crate::Snapshot;
+#[derive(Clone, Debug, PartialEq, Eq, bon::Builder)]
+pub struct Snapshot {
+    #[builder(into)]
+    pub url: std::string::String,
+    #[builder(into)]
+    pub data: std::vec::Vec<u8>,
+    pub start_timestamp: jiff::Timestamp,
+    pub end_timestamp: Option<jiff::Timestamp>,
+}
 
 #[derive(Clone, Debug, bon::Builder)]
 pub struct Options {

--- a/lib/asimov-snapshot/src/storage.rs
+++ b/lib/asimov-snapshot/src/storage.rs
@@ -28,9 +28,9 @@ pub trait Storage {
 
     fn save_timestamp(&self, _snapshot: &Snapshot) -> Result<()>;
 
-    fn read(&self, _url: impl AsRef<str>, _timestamp: Timestamp) -> Result<Vec<u8>>;
+    fn read(&self, _url: impl AsRef<str>, _timestamp: Timestamp) -> Result<Snapshot>;
 
-    fn read_current(&self, url: impl AsRef<str>) -> Result<Vec<u8>> {
+    fn read_current(&self, url: impl AsRef<str>) -> Result<Snapshot> {
         let ts = self.current_version(&url)?;
         self.read(&url, ts)
     }

--- a/lib/asimov-snapshot/src/storage.rs
+++ b/lib/asimov-snapshot/src/storage.rs
@@ -12,7 +12,7 @@ use crate::Snapshot;
 
 pub trait Storage {
     fn save(&self, snapshot: &Snapshot) -> Result<()> {
-        self.save_timestamp(snapshot)?;
+        self.save_snapshot(snapshot)?;
         match self.current_version(&snapshot.url) {
             Ok(current) if snapshot.start_timestamp > current => {
                 self.set_current_version(&snapshot.url, snapshot.start_timestamp)
@@ -26,7 +26,7 @@ pub trait Storage {
         }
     }
 
-    fn save_timestamp(&self, _snapshot: &Snapshot) -> Result<()>;
+    fn save_snapshot(&self, _snapshot: &Snapshot) -> Result<()>;
 
     fn read(&self, _url: impl AsRef<str>, _timestamp: Timestamp) -> Result<Snapshot>;
 

--- a/lib/asimov-snapshot/src/storage.rs
+++ b/lib/asimov-snapshot/src/storage.rs
@@ -8,31 +8,25 @@ pub use fs::*;
 use jiff::Timestamp;
 use std::{io::Result, string::String, vec::Vec};
 
+use crate::Snapshot;
+
 pub trait Storage {
-    fn save(
-        &self,
-        url: impl AsRef<str>,
-        timestamp: Timestamp,
-        data: impl AsRef<[u8]>,
-    ) -> Result<()> {
-        self.save_timestamp(&url, timestamp, data)?;
-        match self.current_version(&url) {
-            Ok(current) if timestamp > current => self.set_current_version(&url, timestamp),
+    fn save(&self, snapshot: &Snapshot) -> Result<()> {
+        self.save_timestamp(snapshot)?;
+        match self.current_version(&snapshot.url) {
+            Ok(current) if snapshot.start_timestamp > current => {
+                self.set_current_version(&snapshot.url, snapshot.start_timestamp)
+            },
             Ok(_) => Ok(()),
 
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                self.set_current_version(&url, timestamp)
+                self.set_current_version(&snapshot.url, snapshot.start_timestamp)
             },
             Err(err) => Err(err),
         }
     }
 
-    fn save_timestamp(
-        &self,
-        _url: impl AsRef<str>,
-        _timestamp: Timestamp,
-        _data: impl AsRef<[u8]>,
-    ) -> Result<()>;
+    fn save_timestamp(&self, _snapshot: &Snapshot) -> Result<()>;
 
     fn read(&self, _url: impl AsRef<str>, _timestamp: Timestamp) -> Result<Vec<u8>>;
 

--- a/lib/asimov-snapshot/src/storage/fs.rs
+++ b/lib/asimov-snapshot/src/storage/fs.rs
@@ -30,7 +30,7 @@ impl Fs {
 
 impl super::Storage for Fs {
     #[tracing::instrument(skip_all, fields(url = snapshot.url))]
-    fn save_timestamp(&self, snapshot: &Snapshot) -> Result<()> {
+    fn save_snapshot(&self, snapshot: &Snapshot) -> Result<()> {
         let url_hash = hex::encode(sha256(&snapshot.url));
         let final_url_dir = std::path::Path::new(&url_hash);
 

--- a/lib/asimov-snapshot/src/storage/fs.rs
+++ b/lib/asimov-snapshot/src/storage/fs.rs
@@ -80,6 +80,23 @@ impl super::Storage for Fs {
         permissions.set_readonly(true);
         snapshot_file.set_permissions(permissions)?;
 
+        if let Some(end_ts) = snapshot.end_timestamp {
+            let end_ts_path = tmp_snapshot_dir_path.join("end-timestamp");
+            tracing::debug!("Writing snapshot end_timestamp file");
+            let mut end_ts_file = tmp_dir.create(&end_ts_path)?;
+            end_ts_file.write_all(
+                end_ts
+                    .strftime(TIMESTAMP_FORMAT_STRING)
+                    .to_string()
+                    .as_bytes(),
+            )?;
+
+            tracing::debug!("Setting snapshot end_timestamp file permissions");
+            let mut permissions = end_ts_file.metadata()?.permissions();
+            permissions.set_readonly(true);
+            end_ts_file.set_permissions(permissions)?;
+        }
+
         let final_snapshot_dir_path = final_url_dir.join(ts.to_string());
         tracing::debug!("Creating final snapshot directory");
         self.root.create_dir_all(&final_snapshot_dir_path)?;

--- a/lib/asimov-snapshot/src/storage/fs.rs
+++ b/lib/asimov-snapshot/src/storage/fs.rs
@@ -372,7 +372,9 @@ mod tests {
 
     #[test]
     fn storage() {
-        tracing_subscriber::fmt::init();
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .init();
 
         let tmp_dir = tempfile::Builder::new()
             .prefix("asimov-snapshot-fs-test")

--- a/lib/asimov-snapshot/src/storage/fs.rs
+++ b/lib/asimov-snapshot/src/storage/fs.rs
@@ -73,15 +73,17 @@ impl super::Storage for Fs {
         tracing::debug!("Creating snapshot directory");
         tmp_dir.create_dir(&tmp_snapshot_dir_path)?;
 
-        tracing::debug!("Writing snapshot data file");
-        let snapshot_path = tmp_snapshot_dir_path.join("data");
-        let mut snapshot_file = tmp_dir.create(snapshot_path)?;
-        snapshot_file.write_all(snapshot.data.as_ref())?;
+        {
+            tracing::debug!("Writing snapshot data file");
+            let snapshot_path = tmp_snapshot_dir_path.join("data");
+            let mut snapshot_file = tmp_dir.create(snapshot_path)?;
+            snapshot_file.write_all(snapshot.data.as_ref())?;
 
-        tracing::debug!("Setting snapshot data file permissions");
-        let mut permissions = snapshot_file.metadata()?.permissions();
-        permissions.set_readonly(true);
-        snapshot_file.set_permissions(permissions)?;
+            tracing::debug!("Setting snapshot data file permissions");
+            let mut permissions = snapshot_file.metadata()?.permissions();
+            permissions.set_readonly(true);
+            snapshot_file.set_permissions(permissions)?;
+        }
 
         if let Some(end_ts) = snapshot.end_timestamp {
             let end_ts_path = tmp_snapshot_dir_path.join("end-timestamp");

--- a/lib/asimov-snapshot/src/storage/fs.rs
+++ b/lib/asimov-snapshot/src/storage/fs.rs
@@ -100,7 +100,7 @@ impl super::Storage for Fs {
             end_ts_file.set_permissions(permissions)?;
         }
 
-        let final_snapshot_dir_path = final_url_dir.join(ts.to_string());
+        let final_snapshot_dir_path = final_url_dir.join(&ts);
         tracing::debug!("Creating final snapshot directory");
         self.root.create_dir_all(&final_snapshot_dir_path)?;
         tracing::debug!("Moving snapshot directory to final location");

--- a/lib/asimov-snapshot/src/storage/fs.rs
+++ b/lib/asimov-snapshot/src/storage/fs.rs
@@ -374,9 +374,7 @@ mod tests {
 
     #[test]
     fn storage() {
-        tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .init();
+        tracing_subscriber::fmt::init();
 
         let tmp_dir = tempfile::Builder::new()
             .prefix("asimov-snapshot-fs-test")


### PR DESCRIPTION
Updates:
1. Storage layout from
   ```
   $root/sha256($url)/$timestamp.jsonld
   $root/sha256($url)/current -> $timestamp.jsonld
   ```
   to
   ```
   $root/sha256($url)/$timestamp/data           # file
   $root/sha256($url)/$timestamp/end-timestamp  # file
   $root/sha256($url)/current -> $timestamp     # symlink
   ```

2. Saves the timestamp when snapshot operation finished.
3. Writes are made under `$root/.tmp/$rand_tmp_dir/$timestamp` until everything is ready, then the snapshot directory is moved to `$root/sha256($url)/$timestamp`. 
4. Updates the snapshotter to support `cataloger`
5. Refactors the snapshotter public API a bit. Breaks downstream only very lightly and I have patches for asimov-cli and asimov-snapshot-cli, will create PRs.

Tested with asimov-cli and asimov-snapshot-cli.

**_Not compatible_** with previous snapshot format. I think this is ok?


@race-of-sloths