### PR TITLE
Install modules as directories

### DIFF
--- a/rust/lib/asimov-core/src/module_name.rs
+++ b/rust/lib/asimov-core/src/module_name.rs
@@ -1,5 +1,153 @@
 // This is free and unencumbered software released into the public domain.
 
-use alloc::string::String;
+use alloc::{borrow::ToOwned, string::String};
+use core::{borrow::Borrow, fmt, ops::Deref, str::FromStr};
 
-pub type ModuleName = String;
+/// The name of a module.
+///
+/// A name consists only of lowercase letters, digits and hyphens, starts with a letter, and is at
+/// most 64 characters long. A trailing hyphen is refused as well, which the specification permits
+/// but `asimov-module-kit` does not create.
+///
+/// See: <https://asimov-specs.github.io/module-manifest/#name-field>
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "String", into = "String"))]
+pub struct ModuleName(String);
+
+impl ModuleName {
+    pub const MAX_LENGTH: usize = 64;
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for ModuleName {
+    type Error = InvalidModuleName;
+
+    fn try_from(name: String) -> Result<Self, Self::Error> {
+        let valid = name.len() <= Self::MAX_LENGTH
+            && name.starts_with(|c: char| c.is_ascii_lowercase())
+            && !name.ends_with('-')
+            && name
+                .bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-');
+
+        if valid {
+            Ok(Self(name))
+        } else {
+            Err(InvalidModuleName(name))
+        }
+    }
+}
+
+impl TryFrom<&str> for ModuleName {
+    type Error = InvalidModuleName;
+
+    fn try_from(name: &str) -> Result<Self, Self::Error> {
+        name.to_owned().try_into()
+    }
+}
+
+impl FromStr for ModuleName {
+    type Err = InvalidModuleName;
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        name.try_into()
+    }
+}
+
+impl From<ModuleName> for String {
+    fn from(name: ModuleName) -> Self {
+        name.0
+    }
+}
+
+impl AsRef<str> for ModuleName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Borrow<str> for ModuleName {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for ModuleName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for ModuleName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvalidModuleName(pub String);
+
+impl fmt::Display for InvalidModuleName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid module name `{}`", self.0)
+    }
+}
+
+impl core::error::Error for InvalidModuleName {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_module_names() {
+        for name in [
+            "ipfs",
+            "search-google-fetcher",
+            "x",
+            "a1-b2",
+            &"a".repeat(ModuleName::MAX_LENGTH),
+        ] {
+            assert!(name.parse::<ModuleName>().is_ok(), "{name}");
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_names() {
+        for name in [
+            "",
+            "0-leading-digit",
+            "-sample",
+            "Sample",
+            "sample name",
+            "sample_name",
+            "sample-",
+            &"a".repeat(ModuleName::MAX_LENGTH + 1),
+        ] {
+            assert!(name.parse::<ModuleName>().is_err(), "{name}");
+        }
+    }
+
+    #[test]
+    fn rejects_names_that_are_not_path_components() {
+        for name in [
+            "..",
+            "../victim",
+            "sample/../../victim",
+            "a/b",
+            "sample.json",
+        ] {
+            assert!(name.parse::<ModuleName>().is_err(), "{name}");
+        }
+    }
+}

--- a/rust/lib/asimov-directory/src/fs/module_iterators.rs
+++ b/rust/lib/asimov-directory/src/fs/module_iterators.rs
@@ -27,13 +27,9 @@ impl crate::ModuleNameIterator for ModuleNameIterator {
                 && let Some(entry_name) = entry.file_name().to_str()
                 && !entry_name.starts_with(".")
                 && let Ok(entry_type) = entry.file_type().await
-                && (entry_type.is_dir() || entry_type.is_file() || entry_type.is_symlink())
+                && (entry_type.is_dir() || entry_type.is_symlink())
             {
-                let entry_stem = [".json", ".yaml"]
-                    .iter()
-                    .find_map(|&ext| entry_name.strip_suffix(ext))
-                    .unwrap_or(entry_name);
-                return Some(entry_stem.into());
+                return Some(entry_name.into());
             }
         }
         None
@@ -61,38 +57,13 @@ impl crate::ModuleManifestIterator for ModuleManifestIterator {
                 && let Some(entry_name) = entry.file_name().to_str()
                 && !entry_name.starts_with(".")
                 && let Ok(entry_type) = entry.file_type().await
+                && (entry_type.is_dir() || entry_type.is_symlink())
+                && let Ok(content) = tokio::fs::read(entry.path().join("manifest.json")).await
+                && let Ok(manifest) = serde_json::from_slice(&content)
             {
-                let manifest = if entry_type.is_dir() {
-                    let dir = entry.path();
-                    let mut manifest = None;
-                    for file in ["manifest.json", "manifest.yaml", "manifest.yml"] {
-                        manifest = read_manifest(&dir.join(file)).await;
-                        if manifest.is_some() {
-                            break;
-                        }
-                    }
-                    manifest
-                } else if entry_type.is_file() || entry_type.is_symlink() {
-                    read_manifest(&entry.path()).await
-                } else {
-                    None
-                };
-
-                if let Some(manifest) = manifest {
-                    return Some(manifest);
-                }
+                return Some(manifest);
             }
         }
         None
-    }
-}
-
-async fn read_manifest(path: &std::path::Path) -> Option<InstalledModuleManifest> {
-    let content = tokio::fs::read(path).await.ok()?;
-
-    match path.extension().and_then(|ext| ext.to_str())? {
-        "json" => serde_json::from_slice(&content).ok(),
-        "yaml" | "yml" => serde_yaml_ng::from_slice(&content).ok(),
-        _ => None,
     }
 }

--- a/rust/lib/asimov-directory/src/fs/module_iterators.rs
+++ b/rust/lib/asimov-directory/src/fs/module_iterators.rs
@@ -27,7 +27,7 @@ impl crate::ModuleNameIterator for ModuleNameIterator {
                 && let Some(entry_name) = entry.file_name().to_str()
                 && !entry_name.starts_with(".")
                 && let Ok(entry_type) = entry.file_type().await
-                && (entry_type.is_file() || entry_type.is_symlink())
+                && (entry_type.is_dir() || entry_type.is_file() || entry_type.is_symlink())
             {
                 let entry_stem = [".json", ".yaml"]
                     .iter()
@@ -61,21 +61,38 @@ impl crate::ModuleManifestIterator for ModuleManifestIterator {
                 && let Some(entry_name) = entry.file_name().to_str()
                 && !entry_name.starts_with(".")
                 && let Ok(entry_type) = entry.file_type().await
-                && (entry_type.is_file() || entry_type.is_symlink())
-                && let Some(ext) = std::path::Path::new(entry_name)
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                && (ext == "json" || ext == "yaml" || ext == "yml")
-                && let Ok(content) = tokio::fs::read(entry.path()).await
-                && let Some(manifest) = match ext {
-                    "json" => serde_json::from_slice(&content).ok(),
-                    "yaml" | "yml" => serde_yaml_ng::from_slice(&content).ok(),
-                    _ => None,
-                }
             {
-                return Some(manifest);
+                let manifest = if entry_type.is_dir() {
+                    let dir = entry.path();
+                    let mut manifest = None;
+                    for file in ["manifest.json", "manifest.yaml", "manifest.yml"] {
+                        manifest = read_manifest(&dir.join(file)).await;
+                        if manifest.is_some() {
+                            break;
+                        }
+                    }
+                    manifest
+                } else if entry_type.is_file() || entry_type.is_symlink() {
+                    read_manifest(&entry.path()).await
+                } else {
+                    None
+                };
+
+                if let Some(manifest) = manifest {
+                    return Some(manifest);
+                }
             }
         }
         None
+    }
+}
+
+async fn read_manifest(path: &std::path::Path) -> Option<InstalledModuleManifest> {
+    let content = tokio::fs::read(path).await.ok()?;
+
+    match path.extension().and_then(|ext| ext.to_str())? {
+        "json" => serde_json::from_slice(&content).ok(),
+        "yaml" | "yml" => serde_yaml_ng::from_slice(&content).ok(),
+        _ => None,
     }
 }

--- a/rust/lib/asimov-directory/src/fs/module_iterators.rs
+++ b/rust/lib/asimov-directory/src/fs/module_iterators.rs
@@ -28,8 +28,9 @@ impl crate::ModuleNameIterator for ModuleNameIterator {
                 && !entry_name.starts_with(".")
                 && let Ok(entry_type) = entry.file_type().await
                 && (entry_type.is_dir() || entry_type.is_symlink())
+                && let Ok(module_name) = ModuleName::try_from(entry_name)
             {
-                return Some(entry_name.into());
+                return Some(module_name);
             }
         }
         None

--- a/rust/lib/asimov-installer/Cargo.toml
+++ b/rust/lib/asimov-installer/Cargo.toml
@@ -68,6 +68,9 @@ getenv = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true, features = ["attributes"] }
 tracing-subscriber = { workspace = true, optional = true }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+
 # Preview locally with: RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
 [package.metadata.docs.rs]
 all-features = true

--- a/rust/lib/asimov-installer/src/installer.rs
+++ b/rust/lib/asimov-installer/src/installer.rs
@@ -1,7 +1,7 @@
 // This is free and unencumbered software released into the public domain.
 
 use alloc::format;
-use asimov_module::{InstalledModuleManifest, ModuleManifest, tracing};
+use asimov_module::{InstalledModuleManifest, ModuleManifest, ModuleName, tracing};
 use std::{
     boxed::Box,
     path::{Path, PathBuf},
@@ -45,6 +45,7 @@ pub struct InstallOptions {
 
 #[derive(Clone, Debug)]
 struct Preinstalled {
+    module_name: ModuleName,
     manifest: ModuleManifest,
     version: String,
     readme: Option<String>,
@@ -59,17 +60,18 @@ impl Installer {
     /// ```rust,no_run
     /// # use asimov_installer::{Installer, InstallOptions};
     /// let i = Installer::default();
-    /// i.install_module("foobar", &InstallOptions::default());
+    /// let module = "foobar".parse().unwrap();
+    /// i.install_module(&module, &InstallOptions::default());
     /// ```
     pub async fn install_module(
         &self,
-        module: impl AsRef<str> + 'static,
+        module_name: &ModuleName,
         options: &InstallOptions,
     ) -> Result<(), InstallError> {
-        let work_dir = self.work_dir(module.as_ref()).await?;
+        let work_dir = self.work_dir(module_name).await?;
 
         let preinstalled = self
-            .preinstall(module.as_ref(), options, work_dir.path())
+            .preinstall(module_name, options, work_dir.path())
             .await?;
 
         self.finish_install(preinstalled, work_dir.path()).await?;
@@ -79,7 +81,7 @@ impl Installer {
 
     pub async fn fetch_latest_release(
         &self,
-        module_name: impl AsRef<str>,
+        module_name: &ModuleName,
     ) -> Result<String, FetchError> {
         github::fetch_latest_release(&self.client, module_name).await
     }
@@ -87,15 +89,14 @@ impl Installer {
     /// ```rust,no_run
     /// # use asimov_installer::{Installer, InstallOptions};
     /// let i = Installer::default();
-    /// i.upgrade_module("foobar", &InstallOptions::default());
+    /// let module = "foobar".parse().unwrap();
+    /// i.upgrade_module(&module, &InstallOptions::default());
     /// ```
     pub async fn upgrade_module(
         &self,
-        module: impl AsRef<str> + 'static,
+        module_name: &ModuleName,
         options: &InstallOptions,
     ) -> Result<(), UpgradeError> {
-        let module_name = module.as_ref();
-
         let version = if let Some(ref want_version) = options.version {
             want_version.clone()
         } else {
@@ -106,7 +107,7 @@ impl Installer {
         match current_version {
             Some(current) if current == version => return Ok(()),
             Some(_) => (),
-            None => tracing::debug!(module_name, "installed module does not define a version"),
+            None => tracing::debug!(%module_name, "installed module does not define a version"),
         };
 
         let work_dir = self.work_dir(module_name).await?;
@@ -130,13 +131,10 @@ impl Installer {
         Ok(())
     }
 
-    pub async fn uninstall_module(
-        &self,
-        module_name: impl AsRef<str>,
-    ) -> Result<(), UninstallError> {
-        let manifest = self.registry.read_manifest(&module_name).await?;
+    pub async fn uninstall_module(&self, module_name: &ModuleName) -> Result<(), UninstallError> {
+        let manifest = self.registry.read_manifest(module_name).await?;
 
-        self.registry.disable_module(&module_name).await?;
+        self.registry.disable_module(module_name).await?;
 
         for program in &manifest.manifest.provides.programs {
             self.registry
@@ -145,12 +143,12 @@ impl Installer {
                 .map_err(|e| UninstallError::RemoveBinary(program.into(), e))?;
         }
 
-        self.registry.remove_module(&module_name).await?;
+        self.registry.remove_module(module_name).await?;
 
         Ok(())
     }
 
-    async fn work_dir(&self, module_name: &str) -> Result<tempfile::TempDir, WorkDirError> {
+    async fn work_dir(&self, module_name: &ModuleName) -> Result<tempfile::TempDir, WorkDirError> {
         self.registry
             .create_file_tree()
             .await
@@ -166,7 +164,7 @@ impl Installer {
 
     async fn preinstall(
         &self,
-        module_name: &str,
+        module_name: &ModuleName,
         options: &InstallOptions,
         temp_dir: &Path,
     ) -> Result<Preinstalled, PreinstallError> {
@@ -199,6 +197,9 @@ impl Installer {
             .build();
         let subdeps = &manifest.requires.modules;
         for module in subdeps {
+            let module = ModuleName::try_from(module.clone())
+                .map_err(PreinstallError::InvalidDependencyName)?;
+
             if self
                 .registry
                 .is_module_installed(&module)
@@ -207,9 +208,9 @@ impl Installer {
             {
                 continue;
             }
-            Box::pin(self.install_module(module.clone(), &options))
+            Box::pin(self.install_module(&module, &options))
                 .await
-                .map_err(|e| PreinstallError::Dependency(module.clone(), Box::new(e)))?;
+                .map_err(|e| PreinstallError::Dependency(module.into_string(), Box::new(e)))?;
         }
 
         match github::fetch_checksum(&self.client, &asset_url).await {
@@ -278,6 +279,8 @@ impl Installer {
         };
 
         Ok(Preinstalled {
+            module_name: ModuleName::try_from(manifest.name.clone())
+                .map_err(PreinstallError::InvalidModuleName)?,
             manifest,
             version,
             readme,
@@ -291,13 +294,13 @@ impl Installer {
         work_dir: &Path,
     ) -> Result<(), FinishInstallError> {
         let Preinstalled {
+            module_name,
             manifest,
             version,
             readme,
             extract_dir,
         } = preinstalled;
 
-        let module_name = manifest.name.clone();
         let module_dir = work_dir.join("module");
 
         tokio::fs::create_dir(&module_dir)

--- a/rust/lib/asimov-installer/src/installer.rs
+++ b/rust/lib/asimov-installer/src/installer.rs
@@ -38,6 +38,13 @@ pub struct InstallOptions {
     pub model_size: Option<String>,
 }
 
+#[derive(Clone, Debug)]
+struct Preinstalled {
+    manifest: ModuleManifest,
+    version: String,
+    readme: Option<String>,
+}
+
 impl Installer {
     pub fn new(client: reqwest::Client, registry: Registry) -> Self {
         Self { client, registry }
@@ -58,12 +65,11 @@ impl Installer {
             .tempdir()
             .map_err(InstallError::CreateTempDir)?;
 
-        let (manifest, version) = self
+        let preinstalled = self
             .preinstall(module.as_ref(), options, temp_dir.path())
             .await?;
 
-        self.finish_install(version.as_ref(), manifest, temp_dir.path())
-            .await?;
+        self.finish_install(preinstalled, temp_dir.path()).await?;
 
         Ok(())
     }
@@ -108,15 +114,14 @@ impl Installer {
         // check if currently enabled, have to re-enable after upgrade
         let was_enabled = self.registry.is_module_enabled(module_name).await?;
 
-        let (manifest, version) = self
+        let preinstalled = self
             .preinstall(module_name, options, temp_dir.path())
             .await?;
 
         // now ok to uninstall old version
         self.uninstall_module(module_name).await?;
 
-        self.finish_install(&version, manifest, temp_dir.path())
-            .await?;
+        self.finish_install(preinstalled, temp_dir.path()).await?;
 
         if was_enabled {
             self.registry.enable_module(module_name).await?;
@@ -140,7 +145,7 @@ impl Installer {
                 .map_err(|e| UninstallError::RemoveBinary(program.into(), e))?;
         }
 
-        self.registry.remove_manifest(&module_name).await?;
+        self.registry.remove_module(&module_name).await?;
 
         Ok(())
     }
@@ -150,7 +155,7 @@ impl Installer {
         module_name: &str,
         options: &InstallOptions,
         temp_dir: &Path,
-    ) -> Result<(ModuleManifest, String), PreinstallError> {
+    ) -> Result<Preinstalled, PreinstallError> {
         let platform = platform::detect_platform();
 
         let version = if let Some(ref want_version) = options.version {
@@ -253,15 +258,29 @@ impl Installer {
             asimov_huggingface::ensure_file(repo, filename)?;
         }
 
-        Ok((manifest, version))
+        let readme = match find_readme(&extract_dir).await {
+            Some(readme) => Some(readme),
+            None => github::fetch_readme(&self.client, module_name, &version).await,
+        };
+
+        Ok(Preinstalled {
+            manifest,
+            version,
+            readme,
+        })
     }
 
     async fn finish_install(
         &self,
-        version: &str,
-        manifest: ModuleManifest,
+        preinstalled: Preinstalled,
         temp_dir: &Path,
     ) -> Result<(), FinishInstallError> {
+        let Preinstalled {
+            manifest,
+            version,
+            readme,
+        } = preinstalled;
+
         let extract_dir = temp_dir.join("extract");
 
         for program in &manifest.provides.programs {
@@ -271,16 +290,70 @@ impl Installer {
             #[cfg(windows)]
             let src = src.with_extension("exe");
 
-            self.registry.add_binary(program, &src).await?;
+            self.registry
+                .add_binary(&manifest.name, program, &src)
+                .await?;
         }
 
+        let module_name = manifest.name.clone();
+
         let installed_manifest = InstalledModuleManifest {
-            version: Some(version.into()),
+            version: Some(version),
             manifest,
         };
 
         self.registry.add_manifest(installed_manifest).await?;
 
+        if let Some(readme) = readme {
+            self.registry.add_readme(&module_name, readme).await?;
+        }
+
         Ok(())
+    }
+}
+
+async fn find_readme(extract_dir: &Path) -> Option<String> {
+    let mut entries = tokio::fs::read_dir(extract_dir).await.ok()?;
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+
+        if !file_name.to_ascii_uppercase().starts_with("README") {
+            continue;
+        }
+
+        if !entry
+            .file_type()
+            .await
+            .map(|file_type| file_type.is_file())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        return tokio::fs::read_to_string(entry.path()).await.ok();
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn find_readme_in_archive() {
+        let dir = tempfile::tempdir().unwrap();
+
+        assert_eq!(find_readme(dir.path()).await, None);
+
+        std::fs::create_dir(dir.path().join("README")).unwrap();
+        assert_eq!(find_readme(dir.path()).await, None);
+
+        std::fs::write(dir.path().join("readme.md"), "# Hello").unwrap();
+        assert_eq!(find_readme(dir.path()).await.as_deref(), Some("# Hello"));
     }
 }

--- a/rust/lib/asimov-installer/src/installer.rs
+++ b/rust/lib/asimov-installer/src/installer.rs
@@ -2,7 +2,11 @@
 
 use alloc::format;
 use asimov_module::{InstalledModuleManifest, ModuleManifest, tracing};
-use std::{boxed::Box, path::Path, string::String};
+use std::{
+    boxed::Box,
+    path::{Path, PathBuf},
+    string::String,
+};
 
 pub mod error;
 use error::*;
@@ -44,6 +48,7 @@ struct Preinstalled {
     manifest: ModuleManifest,
     version: String,
     readme: Option<String>,
+    extract_dir: PathBuf,
 }
 
 impl Installer {
@@ -61,16 +66,13 @@ impl Installer {
         module: impl AsRef<str> + 'static,
         options: &InstallOptions,
     ) -> Result<(), InstallError> {
-        let temp_dir = tempfile::Builder::new()
-            .prefix("asimov-module-installer")
-            .tempdir()
-            .map_err(InstallError::CreateTempDir)?;
+        let work_dir = self.work_dir(module.as_ref()).await?;
 
         let preinstalled = self
-            .preinstall(module.as_ref(), options, temp_dir.path())
+            .preinstall(module.as_ref(), options, work_dir.path())
             .await?;
 
-        self.finish_install(preinstalled, temp_dir.path()).await?;
+        self.finish_install(preinstalled, work_dir.path()).await?;
 
         Ok(())
     }
@@ -107,22 +109,19 @@ impl Installer {
             None => tracing::debug!(module_name, "installed module does not define a version"),
         };
 
-        let temp_dir = tempfile::Builder::new()
-            .prefix("asimov-module-installer")
-            .tempdir()
-            .map_err(UpgradeError::CreateTempDir)?;
+        let work_dir = self.work_dir(module_name).await?;
 
         // check if currently enabled, have to re-enable after upgrade
         let was_enabled = self.registry.is_module_enabled(module_name).await?;
 
         let preinstalled = self
-            .preinstall(module_name, options, temp_dir.path())
+            .preinstall(module_name, options, work_dir.path())
             .await?;
 
         // now ok to uninstall old version
         self.uninstall_module(module_name).await?;
 
-        self.finish_install(preinstalled, temp_dir.path()).await?;
+        self.finish_install(preinstalled, work_dir.path()).await?;
 
         if was_enabled {
             self.registry.enable_module(module_name).await?;
@@ -149,6 +148,20 @@ impl Installer {
         self.registry.remove_module(&module_name).await?;
 
         Ok(())
+    }
+
+    async fn work_dir(&self, module_name: &str) -> Result<tempfile::TempDir, WorkDirError> {
+        self.registry
+            .create_file_tree()
+            .await
+            .map_err(WorkDirError::CreateFileTree)?;
+
+        let install_dir = self.registry.install_dir();
+
+        tempfile::Builder::new()
+            .prefix(&format!(".{module_name}-"))
+            .tempdir_in(install_dir.parent().unwrap_or(install_dir))
+            .map_err(WorkDirError::CreateDir)
     }
 
     async fn preinstall(
@@ -268,76 +281,67 @@ impl Installer {
             manifest,
             version,
             readme,
+            extract_dir,
         })
     }
 
     async fn finish_install(
         &self,
         preinstalled: Preinstalled,
-        temp_dir: &Path,
+        work_dir: &Path,
     ) -> Result<(), FinishInstallError> {
         let Preinstalled {
             manifest,
             version,
             readme,
+            extract_dir,
         } = preinstalled;
 
         let module_name = manifest.name.clone();
+        let module_dir = work_dir.join("module");
 
-        self.registry
-            .create_file_tree()
+        tokio::fs::create_dir(&module_dir)
             .await
-            .map_err(FinishInstallError::CreateFileTree)?;
+            .map_err(|e| FinishInstallError::CreateDir(module_dir.clone(), e))?;
 
-        let install_dir = self.registry.install_dir();
-
-        let module_dir = tempfile::Builder::new()
-            .prefix(&format!(".{module_name}-"))
-            .tempdir_in(install_dir.parent().unwrap_or(install_dir))
-            .map_err(FinishInstallError::CreateDir)?;
-
-        write_module(
-            module_dir.path(),
+        assemble_module(
+            &module_dir,
             InstalledModuleManifest {
                 version: Some(version),
                 manifest,
             },
             readme,
-            &temp_dir.join("extract"),
+            &extract_dir,
         )
         .await?;
 
-        self.registry
-            .add_module(&module_name, module_dir.path())
-            .await?;
-
-        let _ = module_dir.keep();
+        self.registry.add_module(&module_name, &module_dir).await?;
 
         Ok(())
     }
 }
 
-async fn write_module(
-    dir: &Path,
+async fn assemble_module(
+    module_dir: &Path,
     manifest: InstalledModuleManifest,
     readme: Option<String>,
     extract_dir: &Path,
-) -> Result<(), WriteModuleError> {
+) -> Result<(), FinishInstallError> {
     #[cfg(unix)]
     {
         use std::fs::Permissions;
         use std::os::unix::fs::PermissionsExt;
 
-        tokio::fs::set_permissions(dir, Permissions::from_mode(0o755))
+        tokio::fs::set_permissions(module_dir, Permissions::from_mode(0o755))
             .await
-            .map_err(WriteModuleError::SetPermissions)?;
+            .map_err(FinishInstallError::SetPermissions)?;
     }
 
-    let bin_dir = dir.join(asimov_registry::BIN_DIR_NAME);
+    let bin_dir = module_dir.join(asimov_registry::BIN_DIR_NAME);
 
     tokio::fs::create_dir_all(&bin_dir)
         .await
-        .map_err(|e| WriteModuleError::CreateDir(bin_dir.clone(), e))?;
+        .map_err(|e| FinishInstallError::CreateDir(bin_dir.clone(), e))?;
 
     for program in &manifest.manifest.provides.programs {
         let src = extract_dir.join(program);
@@ -348,9 +352,9 @@ async fn write_module(
 
         let dst = bin_dir.join(program);
 
-        tokio::fs::copy(&src, &dst)
+        tokio::fs::rename(&src, &dst)
             .await
-            .map_err(|e| WriteModuleError::CopyBinary(program.clone(), e))?;
+            .map_err(|e| FinishInstallError::MoveBinary(program.clone(), e))?;
 
         #[cfg(unix)]
         {
@@ -359,30 +363,30 @@ async fn write_module(
 
             tokio::fs::set_permissions(&dst, Permissions::from_mode(0o755))
                 .await
-                .map_err(WriteModuleError::SetPermissions)?;
+                .map_err(FinishInstallError::SetPermissions)?;
         }
     }
 
     if let Some(readme) = readme {
-        let readme_path = dir.join(asimov_registry::README_FILE_PATH);
+        let readme_path = module_dir.join(asimov_registry::README_FILE_PATH);
         let doc_dir = readme_path.parent().unwrap();
 
         tokio::fs::create_dir_all(doc_dir)
             .await
-            .map_err(|e| WriteModuleError::CreateDir(doc_dir.into(), e))?;
+            .map_err(|e| FinishInstallError::CreateDir(doc_dir.into(), e))?;
 
         tokio::fs::write(&readme_path, readme)
             .await
-            .map_err(|e| WriteModuleError::WriteFile(readme_path, e))?;
+            .map_err(|e| FinishInstallError::WriteFile(readme_path, e))?;
     }
 
-    let manifest_path = dir.join(asimov_registry::MANIFEST_FILE_NAME);
+    let manifest_path = module_dir.join(asimov_registry::MANIFEST_FILE_NAME);
 
-    let serialized = serde_json::to_vec_pretty(&manifest).map_err(WriteModuleError::Serialize)?;
+    let serialized = serde_json::to_vec_pretty(&manifest).map_err(FinishInstallError::Serialize)?;
 
     tokio::fs::write(&manifest_path, serialized)
         .await
-        .map_err(|e| WriteModuleError::WriteFile(manifest_path, e))
+        .map_err(|e| FinishInstallError::WriteFile(manifest_path, e))
 }
 
 async fn find_readme(extract_dir: &Path) -> Option<String> {

--- a/rust/lib/asimov-installer/src/installer.rs
+++ b/rust/lib/asimov-installer/src/installer.rs
@@ -1,5 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
+use alloc::format;
 use asimov_module::{InstalledModuleManifest, ModuleManifest, tracing};
 use std::{boxed::Box, path::Path, string::String};
 
@@ -281,35 +282,107 @@ impl Installer {
             readme,
         } = preinstalled;
 
-        let extract_dir = temp_dir.join("extract");
-
-        for program in &manifest.provides.programs {
-            let src = extract_dir.join(program);
-
-            // On Windows add the .exe extension to the binary name:
-            #[cfg(windows)]
-            let src = src.with_extension("exe");
-
-            self.registry
-                .add_binary(&manifest.name, program, &src)
-                .await?;
-        }
-
         let module_name = manifest.name.clone();
 
-        let installed_manifest = InstalledModuleManifest {
-            version: Some(version),
-            manifest,
-        };
+        self.registry
+            .create_file_tree()
+            .await
+            .map_err(FinishInstallError::CreateFileTree)?;
 
-        self.registry.add_manifest(installed_manifest).await?;
+        let install_dir = self.registry.install_dir();
 
-        if let Some(readme) = readme {
-            self.registry.add_readme(&module_name, readme).await?;
-        }
+        let module_dir = tempfile::Builder::new()
+            .prefix(&format!(".{module_name}-"))
+            .tempdir_in(install_dir.parent().unwrap_or(install_dir))
+            .map_err(FinishInstallError::CreateDir)?;
+
+        write_module(
+            module_dir.path(),
+            InstalledModuleManifest {
+                version: Some(version),
+                manifest,
+            },
+            readme,
+            &temp_dir.join("extract"),
+        )
+        .await?;
+
+        self.registry
+            .add_module(&module_name, module_dir.path())
+            .await?;
+
+        let _ = module_dir.keep();
 
         Ok(())
     }
+}
+
+async fn write_module(
+    dir: &Path,
+    manifest: InstalledModuleManifest,
+    readme: Option<String>,
+    extract_dir: &Path,
+) -> Result<(), WriteModuleError> {
+    #[cfg(unix)]
+    {
+        use std::fs::Permissions;
+        use std::os::unix::fs::PermissionsExt;
+
+        tokio::fs::set_permissions(dir, Permissions::from_mode(0o755))
+            .await
+            .map_err(WriteModuleError::SetPermissions)?;
+    }
+
+    let bin_dir = dir.join(asimov_registry::BIN_DIR_NAME);
+
+    tokio::fs::create_dir_all(&bin_dir)
+        .await
+        .map_err(|e| WriteModuleError::CreateDir(bin_dir.clone(), e))?;
+
+    for program in &manifest.manifest.provides.programs {
+        let src = extract_dir.join(program);
+
+        // On Windows add the .exe extension to the binary name:
+        #[cfg(windows)]
+        let src = src.with_extension("exe");
+
+        let dst = bin_dir.join(program);
+
+        tokio::fs::copy(&src, &dst)
+            .await
+            .map_err(|e| WriteModuleError::CopyBinary(program.clone(), e))?;
+
+        #[cfg(unix)]
+        {
+            use std::fs::Permissions;
+            use std::os::unix::fs::PermissionsExt;
+
+            tokio::fs::set_permissions(&dst, Permissions::from_mode(0o755))
+                .await
+                .map_err(WriteModuleError::SetPermissions)?;
+        }
+    }
+
+    if let Some(readme) = readme {
+        let readme_path = dir.join(asimov_registry::README_FILE_PATH);
+        let doc_dir = readme_path.parent().unwrap();
+
+        tokio::fs::create_dir_all(doc_dir)
+            .await
+            .map_err(|e| WriteModuleError::CreateDir(doc_dir.into(), e))?;
+
+        tokio::fs::write(&readme_path, readme)
+            .await
+            .map_err(|e| WriteModuleError::WriteFile(readme_path, e))?;
+    }
+
+    let manifest_path = dir.join(asimov_registry::MANIFEST_FILE_NAME);
+
+    let serialized = serde_json::to_vec_pretty(&manifest).map_err(WriteModuleError::Serialize)?;
+
+    tokio::fs::write(&manifest_path, serialized)
+        .await
+        .map_err(|e| WriteModuleError::WriteFile(manifest_path, e))
 }
 
 async fn find_readme(extract_dir: &Path) -> Option<String> {

--- a/rust/lib/asimov-installer/src/installer/error.rs
+++ b/rust/lib/asimov-installer/src/installer/error.rs
@@ -47,8 +47,8 @@ pub enum UninstallError {
     Disable(#[from] registry::DisableError),
     #[error("unable to remove installed module binary `{0}`: {1}")]
     RemoveBinary(String, #[source] registry::RemoveBinaryError),
-    #[error("unable to remove installed module manifest: {0}")]
-    RemoveManifest(#[from] registry::RemoveManifestError),
+    #[error("unable to remove installed module: {0}")]
+    RemoveModule(#[from] registry::RemoveModuleError),
 }
 
 mod common {
@@ -160,6 +160,8 @@ mod common {
         AddBinary(#[from] registry::AddBinaryError),
         #[error("failed to add manifest: {0}")]
         AddManifest(#[from] registry::AddManifestError),
+        #[error("failed to add README: {0}")]
+        AddReadme(#[from] registry::AddReadmeError),
     }
 }
 pub use common::*;

--- a/rust/lib/asimov-installer/src/installer/error.rs
+++ b/rust/lib/asimov-installer/src/installer/error.rs
@@ -12,8 +12,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum InstallError {
-    #[error("failed to create directory for downloading: {0}")]
-    CreateTempDir(io::Error),
+    #[error(transparent)]
+    WorkDir(#[from] WorkDirError),
     #[error(transparent)]
     Preinstall(#[from] PreinstallError),
     #[error(transparent)]
@@ -26,8 +26,8 @@ pub enum UpgradeError {
     Fetch(#[from] FetchError),
     #[error("unable to read current version of module: {0}")]
     CheckVersion(#[from] registry::ModuleVersionError),
-    #[error("failed to create directory for downloading: {0}")]
-    CreateTempDir(io::Error),
+    #[error(transparent)]
+    WorkDir(#[from] WorkDirError),
     #[error("unable to check if module is enabled: {0}")]
     CheckEnabled(#[from] registry::IsModuleEnabledError),
     #[error(transparent)]
@@ -156,30 +156,28 @@ mod common {
     }
 
     #[derive(Debug, Error)]
-    pub enum FinishInstallError {
+    pub enum WorkDirError {
         #[error("failed to create the module file tree: {0}")]
         CreateFileTree(#[source] registry::CreateFileTreeError),
-        #[error("failed to create directory for the module: {0}")]
-        CreateDir(io::Error),
-        #[error(transparent)]
-        WriteModule(#[from] WriteModuleError),
-        #[error("failed to install module: {0}")]
-        AddModule(#[from] registry::AddModuleError),
+        #[error("failed to create directory for installing: {0}")]
+        CreateDir(#[source] io::Error),
     }
 
     #[derive(Debug, Error)]
-    pub enum WriteModuleError {
+    pub enum FinishInstallError {
         #[error("failed to create directory `{0}`: {1}")]
         CreateDir(PathBuf, #[source] io::Error),
         #[error("failed to write `{0}`: {1}")]
         WriteFile(PathBuf, #[source] io::Error),
-        #[error("failed to copy binary `{0}`: {1}")]
-        CopyBinary(String, #[source] io::Error),
+        #[error("failed to move binary `{0}` into place: {1}")]
+        MoveBinary(String, #[source] io::Error),
         #[cfg(unix)]
         #[error("failed to set permissions: {0}")]
         SetPermissions(#[source] io::Error),
         #[error("failed to serialize module manifest: {0}")]
         Serialize(#[source] serde_json::Error),
+        #[error("failed to install module: {0}")]
+        AddModule(#[from] registry::AddModuleError),
     }
 }
 pub use common::*;

--- a/rust/lib/asimov-installer/src/installer/error.rs
+++ b/rust/lib/asimov-installer/src/installer/error.rs
@@ -5,6 +5,7 @@ use asimov_registry::error as registry;
 use std::{
     boxed::Box,
     io,
+    path::PathBuf,
     string::{String, ToString as _},
 };
 use thiserror::Error;
@@ -156,12 +157,29 @@ mod common {
 
     #[derive(Debug, Error)]
     pub enum FinishInstallError {
-        #[error("failed to install binary: {0}")]
-        AddBinary(#[from] registry::AddBinaryError),
-        #[error("failed to add manifest: {0}")]
-        AddManifest(#[from] registry::AddManifestError),
-        #[error("failed to add README: {0}")]
-        AddReadme(#[from] registry::AddReadmeError),
+        #[error("failed to create the module file tree: {0}")]
+        CreateFileTree(#[source] registry::CreateFileTreeError),
+        #[error("failed to create directory for the module: {0}")]
+        CreateDir(io::Error),
+        #[error(transparent)]
+        WriteModule(#[from] WriteModuleError),
+        #[error("failed to install module: {0}")]
+        AddModule(#[from] registry::AddModuleError),
+    }
+
+    #[derive(Debug, Error)]
+    pub enum WriteModuleError {
+        #[error("failed to create directory `{0}`: {1}")]
+        CreateDir(PathBuf, #[source] io::Error),
+        #[error("failed to write `{0}`: {1}")]
+        WriteFile(PathBuf, #[source] io::Error),
+        #[error("failed to copy binary `{0}`: {1}")]
+        CopyBinary(String, #[source] io::Error),
+        #[cfg(unix)]
+        #[error("failed to set permissions: {0}")]
+        SetPermissions(#[source] io::Error),
+        #[error("failed to serialize module manifest: {0}")]
+        Serialize(#[source] serde_json::Error),
     }
 }
 pub use common::*;

--- a/rust/lib/asimov-installer/src/installer/error.rs
+++ b/rust/lib/asimov-installer/src/installer/error.rs
@@ -123,6 +123,11 @@ mod common {
 
     #[derive(Debug, Error)]
     pub enum PreinstallError {
+        #[error(transparent)]
+        InvalidModuleName(asimov_module::InvalidModuleName),
+        #[error("invalid name for a required module: {0}")]
+        InvalidDependencyName(asimov_module::InvalidModuleName),
+
         #[error("failed fetch release: {0}")]
         FetchRelease(FetchError),
 

--- a/rust/lib/asimov-installer/src/installer/github.rs
+++ b/rust/lib/asimov-installer/src/installer/github.rs
@@ -113,6 +113,41 @@ pub async fn fetch_module_manifest(
 }
 
 #[tracing::instrument(skip_all)]
+pub async fn fetch_readme(
+    client: &reqwest::Client,
+    module_name: &str,
+    version: &str,
+) -> Option<String> {
+    // prefer the README of the released version over the one on the default branch
+    for revision in [version, "master", "main"] {
+        let url = format!(
+            "https://raw.githubusercontent.com/asimov-modules/asimov-{module_name}-module/{revision}/README.md",
+        );
+
+        tracing::debug!("trying README URL {url}...");
+
+        let response = match client.get(&url).send().await {
+            Ok(response) => response,
+            Err(err) => {
+                tracing::debug!(?err);
+                continue;
+            },
+        };
+
+        if !response.status().is_success() {
+            continue;
+        }
+
+        match response.text().await {
+            Ok(content) => return Some(content),
+            Err(err) => tracing::debug!(?err),
+        }
+    }
+
+    None
+}
+
+#[tracing::instrument(skip_all)]
 pub async fn fetch_checksum(
     client: &reqwest::Client,
     asset_url: &str,

--- a/rust/lib/asimov-module/src/lib.rs
+++ b/rust/lib/asimov-module/src/lib.rs
@@ -44,7 +44,7 @@ pub fn init_tracing_subscriber(
         .try_init()
 }
 
-pub use asimov_core::ModuleName;
+pub use asimov_core::{InvalidModuleName, ModuleName};
 
 mod models;
 pub use models::*;

--- a/rust/lib/asimov-registry/src/registry.rs
+++ b/rust/lib/asimov-registry/src/registry.rs
@@ -17,16 +17,13 @@ const MANIFEST_FILE_NAMES: [&str; 3] = [MANIFEST_FILE_NAME, "manifest.yaml", "ma
 #[derive(Clone, Debug, bon::Builder)]
 pub struct Options {
     /// Controls whether to search for module manifests from a legacy location.
-    /// The legacy (previous) locations by default are `~/.asimov/modules/*.yaml`
-    /// and `~/.asimov/modules/installed/*.{yaml,json}`.
+    /// The legacy (previous) location by default is `~/.asimov/modules/*.yaml`.
     #[builder(default = true)]
     pub search_legacy_path: bool,
 
     /// Controls whether to automatically move module manifests from a legacy location.
-    /// The legacy (previous) locations by default are `~/.asimov/modules/*.yaml`
-    /// and `~/.asimov/modules/installed/*.{yaml,json}`.
-    /// The new and current location by default is
-    /// `~/.asimov/modules/installed/<name>/manifest.json`.
+    /// The legacy (previous) location by default is `~/.asimov/modules/*.yaml`.
+    /// The new and current location by default is `~/.asimov/modules/installed/<name>/manifest.json`.
     #[builder(default = true)]
     pub auto_migrate_legacy_path: bool,
 }
@@ -105,33 +102,55 @@ impl Registry {
         Ok(())
     }
 
+    pub fn install_dir(&self) -> &Path {
+        &self.install_dir
+    }
+
     pub fn module_dir(&self, module_name: impl AsRef<str>) -> PathBuf {
         self.install_dir.join(module_name.as_ref())
     }
 
-    pub async fn add_manifest(
+    pub async fn add_module(
         &self,
-        manifest: InstalledModuleManifest,
-    ) -> Result<(), AddManifestError> {
-        let module_name = &manifest.manifest.name;
+        module_name: impl AsRef<str>,
+        dir: impl AsRef<Path>,
+    ) -> Result<(), AddModuleError> {
+        let module_name = module_name.as_ref();
 
         if self.is_module_installed(module_name).await.unwrap_or(false) {
-            return Err(AddManifestError::AlreadyInstalled);
+            return Err(AddModuleError::AlreadyInstalled);
         }
 
         let module_dir = self.module_dir(module_name);
 
-        tokio::fs::create_dir_all(&module_dir)
+        tokio::fs::rename(dir.as_ref(), &module_dir)
             .await
-            .map_err(|e| AddManifestError::CreateModuleDir(module_dir.clone(), e))?;
+            .map_err(|e| AddModuleError::Install(dir.as_ref().into(), module_dir.clone(), e))?;
 
-        let manifest_path = module_dir.join(MANIFEST_FILE_NAME);
+        let bin_dir = module_dir.join(BIN_DIR_NAME);
 
-        let serialized = serde_json::to_vec_pretty(&manifest).map_err(SerializeError::Json)?;
+        let mut entries = match tokio::fs::read_dir(&bin_dir).await {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(AddModuleError::ReadBinDir(bin_dir, err)),
+        };
 
-        tokio::fs::write(&manifest_path, serialized)
+        while let Some(entry) = entries
+            .next_entry()
             .await
-            .map_err(|e| AddManifestError::WriteManifest(manifest_path, e))
+            .map_err(|e| AddModuleError::ReadBinDir(bin_dir.clone(), e))?
+        {
+            let program_name = entry.file_name();
+            let Some(program_name) = program_name.to_str() else {
+                continue;
+            };
+
+            self.add_binary(program_name, &entry.path())
+                .await
+                .map_err(|e| AddModuleError::AddBinary(program_name.into(), e))?;
+        }
+
+        Ok(())
     }
 
     pub async fn read_manifest(
@@ -143,23 +162,6 @@ impl Registry {
             .await?
             .ok_or(ManifestError::NotInstalled)?;
         read_manifest(path).await.map_err(Into::into)
-    }
-
-    pub async fn add_readme(
-        &self,
-        module_name: impl AsRef<str>,
-        content: impl AsRef<[u8]>,
-    ) -> Result<(), AddReadmeError> {
-        let readme_path = self.module_dir(module_name).join(README_FILE_PATH);
-        let doc_dir = readme_path.parent().unwrap();
-
-        tokio::fs::create_dir_all(doc_dir)
-            .await
-            .map_err(|e| AddReadmeError::CreateDocDir(doc_dir.into(), e))?;
-
-        tokio::fs::write(&readme_path, content)
-            .await
-            .map_err(|e| AddReadmeError::WriteReadme(readme_path, e))
     }
 
     pub async fn read_readme(
@@ -185,7 +187,6 @@ impl Registry {
             .map_err(Into::into)
     }
 
-    /// Removes a module's entire installation directory.
     pub async fn remove_module(
         &self,
         module_name: impl AsRef<str>,
@@ -208,59 +209,22 @@ impl Registry {
         }
     }
 
-    /// Anything already occupying the symlink's place, such as a binary
-    /// installed in a previous layout, is replaced.
-    pub async fn add_binary(
-        &self,
-        module_name: impl AsRef<str>,
-        program_name: impl AsRef<str>,
-        path: impl AsRef<Path>,
-    ) -> Result<(), AddBinaryError> {
-        let program_name = program_name.as_ref();
-        let bin_dir = self.module_dir(module_name).join(BIN_DIR_NAME);
-
-        tokio::fs::create_dir_all(&bin_dir)
-            .await
-            .map_err(|e| AddBinaryError::CreateBinDir(bin_dir.clone(), e))?;
-
-        let binary_path = bin_dir.join(program_name);
-
-        tokio::fs::copy(path.as_ref(), &binary_path)
-            .await
-            .map_err(AddBinaryError::Copy)?;
-
-        // Make binary executable on Unix systems
-        #[cfg(unix)]
-        {
-            use std::fs::Permissions;
-            use std::os::unix::fs::PermissionsExt;
-
-            let permissions = Permissions::from_mode(0o755);
-            tokio::fs::set_permissions(&binary_path, permissions)
-                .await
-                .map_err(AddBinaryError::MakeExecutable)?;
-        }
-
-        // e.g. `../modules/installed/foo/bin/asimov-foo-fetcher`
+    async fn add_binary(&self, program_name: &str, binary_path: &Path) -> io::Result<()> {
         let target_path = match self
             .exec_dir
             .parent()
             .and_then(|parent| binary_path.strip_prefix(parent).ok())
         {
             Some(suffix) => PathBuf::from("..").join(suffix),
-            None => binary_path,
+            None => binary_path.into(),
         };
 
         let link_path = self.exec_dir.join(program_name);
         let _ = self.remove_binary(program_name).await;
 
-        create_symlink(&target_path, &link_path, false)
-            .await
-            .map_err(AddBinaryError::Symlink)
+        create_symlink(&target_path, &link_path, false).await
     }
 
-    /// Removes only the symlink; the program itself is removed with the module's
-    /// own directory.
     pub async fn remove_binary(&self, name: impl AsRef<str>) -> Result<(), RemoveBinaryError> {
         let binary_path = self.exec_dir.join(name.as_ref());
 
@@ -302,7 +266,6 @@ impl Registry {
                     if self.options.auto_migrate_legacy_path {
                         tracing::debug!(?path, "found a legacy manifest file, migrating...");
 
-                        // once migrated, the module is found by the scan below
                         self.migrate_legacy_manifest(module_name, &path).await.ok();
                     } else {
                         modules.push(manifest);
@@ -464,7 +427,6 @@ impl Registry {
         let path = self.enable_dir.join(module_name.as_ref());
 
         let result = match tokio::fs::remove_file(&path).await {
-            // on Windows a symlink to a directory has to be removed as a directory
             Err(err) if err.kind() != io::ErrorKind::NotFound => {
                 tokio::fs::remove_dir(&path).await.or(Err(err))
             },
@@ -485,7 +447,6 @@ impl Registry {
     async fn link_module(&self, module_name: &str, manifest_path: &Path) -> io::Result<()> {
         let module_dir = self.module_dir(module_name);
 
-        // a manifest in a legacy location has no directory to link to
         let target_path = if manifest_path.starts_with(&module_dir) {
             module_dir
         } else {
@@ -505,7 +466,7 @@ impl Registry {
             // This scope only runs if install_dir and enable_dir share the same parent directory.
 
             if target_path.starts_with(&self.install_dir) {
-                // module is in installed directory: ../installed/<name>
+                // manifest is in installed directory: ../installed/<name>
                 PathBuf::from("..")
                     .join(self.install_dir.file_name().unwrap())
                     .join(target_path.file_name().unwrap())
@@ -556,8 +517,6 @@ impl Registry {
             format!("{module_name}.yml"),
         ];
 
-        // the previous layout was `installed/<name>.json`, the one before that
-        // `modules/<name>.yaml`
         let mut legacy_dirs = vec![self.install_dir.clone()];
         if let Some(parent) = self.install_dir.parent() {
             legacy_dirs.push(parent.into());
@@ -608,7 +567,6 @@ impl Registry {
             )
         })?;
 
-        // an enabled module's symlink now points at the manifest's old location
         if self.is_module_enabled(module_name).await.unwrap_or(false) {
             let _ = self.disable_module(module_name).await;
             let _ = self.link_module(module_name, &dst).await;
@@ -645,7 +603,6 @@ async fn find_manifest_in_dir(module_dir: &Path) -> io::Result<Option<PathBuf>> 
     Ok(None)
 }
 
-/// e.g. `foo` for `installed/foo.json`.
 fn manifest_file_module_name(path: &Path) -> Option<&str> {
     match path.extension().and_then(|ext| ext.to_str()) {
         Some("json") | Some("yaml") | Some("yml") => {

--- a/rust/lib/asimov-registry/src/registry.rs
+++ b/rust/lib/asimov-registry/src/registry.rs
@@ -20,7 +20,6 @@ pub struct Registry {
     install_dir: PathBuf,
     enable_dir: PathBuf,
     exec_dir: PathBuf,
-    legacy_modules_dir: Option<PathBuf>,
 }
 
 impl Default for Registry {
@@ -36,7 +35,6 @@ impl Registry {
             install_dir: dir.join("modules").join("installed"),
             enable_dir: dir.join("modules").join("enabled"),
             exec_dir: dir.join("libexec"),
-            legacy_modules_dir: Some(dir.join("modules")),
         }
     }
 
@@ -55,7 +53,6 @@ impl Registry {
             install_dir: install_dir.into(),
             enable_dir: enable_dir.into(),
             exec_dir: exec_dir.into(),
-            legacy_modules_dir: None,
         }
     }
 
@@ -240,8 +237,6 @@ impl Registry {
             }
         }
 
-        module_names.extend(self.migrate_legacy_modules_dir().await);
-
         let mut modules = Vec::new();
 
         for module_name in module_names {
@@ -425,15 +420,8 @@ impl Registry {
         }
     }
 
-    /// The directories that manifests may reside in directly, from before manifests were installed
-    /// into a directory of their own: `~/.asimov/modules/installed/<name>.yaml`, and older still,
-    /// `~/.asimov/modules/<name>.yaml`.
-    fn legacy_dirs(&self) -> impl Iterator<Item = &Path> {
-        core::iter::once(self.install_dir.as_path()).chain(self.legacy_modules_dir.as_deref())
-    }
-
-    /// Moves the manifest of `module_name` into its own directory, if it is found in a legacy
-    /// location.
+    /// Moves the manifest of `module_name` into its own directory, if it is still a file directly
+    /// in the install directory: `~/.asimov/modules/installed/<name>.{json,yaml,yml}`.
     async fn migrate_legacy_manifest(&self, module_name: &str) {
         let files = [
             format!("{module_name}.json"),
@@ -441,52 +429,14 @@ impl Registry {
             format!("{module_name}.yml"),
         ];
 
-        for dir in self.legacy_dirs() {
-            for file in &files {
-                let path = dir.join(file);
-                if tokio::fs::try_exists(&path).await.unwrap_or(false) {
-                    tracing::debug!(?path, "found a legacy manifest file, migrating...");
-
-                    self.move_legacy_manifest(module_name, &path).await;
-                }
-            }
-        }
-    }
-
-    /// Like [`Self::migrate_legacy_manifest`], but for every manifest in [`Self::legacy_modules_dir`],
-    /// which is not otherwise iterated over. Returns the names of the modules found there.
-    async fn migrate_legacy_modules_dir(&self) -> Vec<String> {
-        let mut module_names = Vec::new();
-
-        let Some(dir) = self.legacy_modules_dir.as_deref() else {
-            return module_names;
-        };
-
-        let Ok(mut read_dir) = tokio::fs::read_dir(dir).await else {
-            return module_names;
-        };
-
-        while let Ok(Some(entry)) = read_dir.next_entry().await {
-            let path = entry.path();
-
-            let Some(module_name) = manifest_file_module_name(&path) else {
-                continue;
-            };
-
-            if tokio::fs::metadata(&path)
-                .await
-                .map(|md| md.is_file())
-                .unwrap_or(false)
-            {
+        for file in &files {
+            let path = self.install_dir.join(file);
+            if tokio::fs::try_exists(&path).await.unwrap_or(false) {
                 tracing::debug!(?path, "found a legacy manifest file, migrating...");
 
                 self.move_legacy_manifest(module_name, &path).await;
-
-                module_names.push(module_name.into());
             }
         }
-
-        module_names
     }
 
     async fn move_legacy_manifest(&self, module_name: &str, path: &Path) {

--- a/rust/lib/asimov-registry/src/registry.rs
+++ b/rust/lib/asimov-registry/src/registry.rs
@@ -14,22 +14,8 @@ pub const BIN_DIR_NAME: &str = "bin";
 
 const MANIFEST_FILE_NAMES: [&str; 3] = [MANIFEST_FILE_NAME, "manifest.yaml", "manifest.yml"];
 
-#[derive(Clone, Debug, bon::Builder)]
-pub struct Options {
-    /// Controls whether to automatically move module manifests from a legacy location.
-    /// The legacy (previous) location by default is `~/.asimov/modules/*.yaml`.
-    /// The new and current location by default is `~/.asimov/modules/installed/<name>/manifest.json`.
-    #[builder(default = true)]
-    pub auto_migrate_legacy_path: bool,
-}
-
-impl Default for Options {
-    fn default() -> Self {
-        Self {
-            auto_migrate_legacy_path: true,
-        }
-    }
-}
+#[derive(Clone, Debug, Default, bon::Builder)]
+pub struct Options {}
 
 #[derive(Clone, Debug)]
 pub struct Registry {
@@ -37,26 +23,22 @@ pub struct Registry {
     enable_dir: PathBuf,
     exec_dir: PathBuf,
     legacy_modules_dir: Option<PathBuf>,
-    options: Options,
 }
 
 impl Default for Registry {
     fn default() -> Self {
-        let dir = asimov_env::paths::asimov_root();
-        let options = Options::default();
-        Self::new(dir, options)
+        Self::new(asimov_env::paths::asimov_root(), Options::default())
     }
 }
 
 impl Registry {
-    pub fn new(asimov_dir: impl Into<PathBuf>, options: Options) -> Self {
+    pub fn new(asimov_dir: impl Into<PathBuf>, _options: Options) -> Self {
         let dir = asimov_dir.into();
         Self {
             install_dir: dir.join("modules").join("installed"),
             enable_dir: dir.join("modules").join("enabled"),
             exec_dir: dir.join("libexec"),
             legacy_modules_dir: Some(dir.join("modules")),
-            options,
         }
     }
 
@@ -64,7 +46,7 @@ impl Registry {
         install_dir: S1,
         enable_dir: S2,
         exec_dir: S3,
-        options: Options,
+        _options: Options,
     ) -> Self
     where
         S1: Into<PathBuf>,
@@ -76,7 +58,6 @@ impl Registry {
             enable_dir: enable_dir.into(),
             exec_dir: exec_dir.into(),
             legacy_modules_dir: None,
-            options,
         }
     }
 
@@ -364,15 +345,29 @@ impl Registry {
     }
 
     pub async fn enable_module(&self, module_name: impl AsRef<str>) -> Result<(), EnableError> {
-        self.migrate_legacy_manifest(module_name.as_ref()).await;
+        let module_name = module_name.as_ref();
 
-        if self.find_manifest_file(&module_name).await?.is_none() {
+        self.migrate_legacy_manifest(module_name).await;
+
+        let module_dir = self.module_dir(module_name);
+
+        if !tokio::fs::try_exists(&module_dir).await? {
             return Err(EnableError::NotInstalled);
         }
 
-        self.link_module(module_name.as_ref())
-            .await
-            .map_err(EnableError::Io)
+        let target_path = self.enable_target(module_name);
+        let src_path = self.enable_dir.join(module_name);
+
+        match create_symlink(&target_path, &src_path, true).await {
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                // disable and retry enabling one more time
+                let _ = self.disable_module(module_name).await;
+
+                create_symlink(&target_path, &src_path, true).await
+            },
+            result => result,
+        }
+        .map_err(Into::into)
     }
 
     pub async fn disable_module(&self, module_name: impl AsRef<str>) -> Result<(), DisableError> {
@@ -396,33 +391,20 @@ impl Registry {
             .map_err(Into::into)
     }
 
-    async fn link_module(&self, module_name: &str) -> io::Result<()> {
-        let module_dir = self.module_dir(module_name);
-
-        let target_path = if self
+    /// The path that the entry in [`Self::enable_dir`] points to for `module_name`.
+    fn enable_target(&self, module_name: &str) -> PathBuf {
+        if self
             .install_dir
             .parent()
             .zip(self.enable_dir.parent())
             .is_some_and(|(a, b)| a == b)
         {
-            // install_dir and enable_dir share a parent, so link relatively: ../installed/<name>
+            // install_dir and enable_dir share a parent, so point relatively: ../installed/<name>
             PathBuf::from("..")
                 .join(self.install_dir.file_name().unwrap())
                 .join(module_name)
         } else {
-            module_dir
-        };
-
-        let src_path = self.enable_dir.join(module_name);
-
-        match create_symlink(&target_path, &src_path, true).await {
-            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                // disable and retry enabling one more time
-                let _ = self.disable_module(module_name).await;
-
-                create_symlink(&target_path, &src_path, true).await
-            },
-            result => result,
+            self.module_dir(module_name)
         }
     }
 
@@ -445,12 +427,8 @@ impl Registry {
     }
 
     /// Moves the manifest of `module_name` into its own directory, if it is found in a legacy
-    /// location. Does nothing unless [`Options::auto_migrate_legacy_path`] is set.
+    /// location.
     async fn migrate_legacy_manifest(&self, module_name: &str) {
-        if !self.options.auto_migrate_legacy_path {
-            return;
-        }
-
         let files = [
             format!("{module_name}.json"),
             format!("{module_name}.yaml"),
@@ -471,10 +449,6 @@ impl Registry {
 
     /// Like [`Self::migrate_legacy_manifest`], but for every module found in a legacy location.
     async fn migrate_legacy_manifests(&self) {
-        if !self.options.auto_migrate_legacy_path {
-            return;
-        }
-
         for dir in self.legacy_dirs() {
             let Ok(mut read_dir) = tokio::fs::read_dir(dir).await else {
                 continue;
@@ -522,9 +496,12 @@ impl Registry {
             return;
         }
 
+        // the entry in `enable_dir` still points at the manifest file that just moved
         if self.is_module_enabled(module_name).await.unwrap_or(false) {
-            let _ = self.disable_module(module_name).await;
-            let _ = self.link_module(module_name).await;
+            let path = self.enable_dir.join(module_name);
+
+            let _ = tokio::fs::remove_file(&path).await;
+            let _ = create_symlink(&self.enable_target(module_name), &path, true).await;
         }
     }
 }

--- a/rust/lib/asimov-registry/src/registry.rs
+++ b/rust/lib/asimov-registry/src/registry.rs
@@ -2,6 +2,7 @@
 
 use alloc::{collections::BTreeSet, format, string::String, vec::Vec};
 use asimov_module::InstalledModuleManifest;
+pub use asimov_module::ModuleName;
 use std::path::{Path, PathBuf};
 use tokio::io;
 
@@ -76,21 +77,15 @@ impl Registry {
         &self.install_dir
     }
 
-    pub fn module_dir(&self, module_name: impl AsRef<str>) -> PathBuf {
-        self.install_dir.join(module_name.as_ref())
+    pub fn module_dir(&self, module_name: &ModuleName) -> PathBuf {
+        self.install_dir.join(module_name.as_str())
     }
 
     pub async fn add_module(
         &self,
-        module_name: impl AsRef<str>,
+        module_name: &ModuleName,
         dir: impl AsRef<Path>,
     ) -> Result<(), AddModuleError> {
-        let module_name = module_name.as_ref();
-
-        if !is_valid_name(module_name) {
-            return Err(AddModuleError::InvalidName(module_name.into()));
-        }
-
         if self.is_module_installed(module_name).await.unwrap_or(false) {
             return Err(AddModuleError::AlreadyInstalled);
         }
@@ -129,9 +124,9 @@ impl Registry {
 
     pub async fn read_manifest(
         &self,
-        module_name: impl AsRef<str>,
+        module_name: &ModuleName,
     ) -> Result<InstalledModuleManifest, ManifestError> {
-        self.migrate_legacy_manifest(module_name.as_ref()).await;
+        self.migrate_legacy_manifest(module_name).await;
 
         let path = self
             .find_manifest_file(module_name)
@@ -142,7 +137,7 @@ impl Registry {
 
     pub async fn read_readme(
         &self,
-        module_name: impl AsRef<str>,
+        module_name: &ModuleName,
     ) -> Result<Option<String>, ReadReadmeError> {
         let readme_path = self.module_dir(module_name).join(README_FILE_PATH);
 
@@ -155,7 +150,7 @@ impl Registry {
 
     pub async fn module_version(
         &self,
-        module_name: impl AsRef<str>,
+        module_name: &ModuleName,
     ) -> Result<Option<String>, ModuleVersionError> {
         self.read_manifest(module_name)
             .await
@@ -163,21 +158,14 @@ impl Registry {
             .map_err(Into::into)
     }
 
-    pub async fn remove_module(
-        &self,
-        module_name: impl AsRef<str>,
-    ) -> Result<(), RemoveModuleError> {
-        if !is_valid_name(module_name.as_ref()) {
-            return Err(RemoveModuleError::InvalidName(module_name.as_ref().into()));
-        }
+    pub async fn remove_module(&self, module_name: &ModuleName) -> Result<(), RemoveModuleError> {
+        self.migrate_legacy_manifest(module_name).await;
 
-        self.migrate_legacy_manifest(module_name.as_ref()).await;
-
-        if self.find_manifest_file(&module_name).await?.is_none() {
+        if self.find_manifest_file(module_name).await?.is_none() {
             return Err(RemoveModuleError::NotInstalled);
         }
 
-        let module_dir = self.module_dir(&module_name);
+        let module_dir = self.module_dir(module_name);
 
         tokio::fs::remove_dir_all(&module_dir)
             .await
@@ -203,7 +191,7 @@ impl Registry {
     pub async fn remove_binary(&self, name: impl AsRef<str>) -> Result<(), RemoveBinaryError> {
         let name = name.as_ref();
 
-        if !is_valid_name(name) {
+        if !is_valid_program_name(name) {
             return Err(RemoveBinaryError::InvalidName(name.into()));
         }
 
@@ -243,18 +231,26 @@ impl Registry {
                 .map(|md| md.is_dir())
                 .unwrap_or(false)
             {
-                module_names.insert(name);
-            } else if let Some(module_name) = manifest_file_module_name(Path::new(&name)) {
-                self.migrate_legacy_manifest(module_name).await;
+                let Ok(module_name) = ModuleName::try_from(name) else {
+                    continue;
+                };
 
-                module_names.insert(module_name.into());
+                module_names.insert(module_name);
+            } else if let Some(name) = manifest_file_module_name(Path::new(&name)) {
+                let Ok(module_name) = ModuleName::try_from(name) else {
+                    continue;
+                };
+
+                self.migrate_legacy_manifest(&module_name).await;
+
+                module_names.insert(module_name);
             }
         }
 
         let mut modules = Vec::new();
 
         for module_name in module_names {
-            let manifest_path = self.module_dir(module_name).join(MANIFEST_FILE_NAME);
+            let manifest_path = self.module_dir(&module_name).join(MANIFEST_FILE_NAME);
 
             if !tokio::fs::try_exists(&manifest_path)
                 .await
@@ -293,6 +289,10 @@ impl Registry {
                 continue;
             };
 
+            let Ok(module_name) = ModuleName::try_from(module_name) else {
+                continue;
+            };
+
             if !tokio::fs::symlink_metadata(entry.path())
                 .await
                 .map(|md| md.is_symlink())
@@ -327,9 +327,9 @@ impl Registry {
 
     pub async fn is_module_installed(
         &self,
-        module_name: impl AsRef<str>,
+        module_name: &ModuleName,
     ) -> Result<bool, IsModuleInstalledError> {
-        self.migrate_legacy_manifest(module_name.as_ref()).await;
+        self.migrate_legacy_manifest(module_name).await;
 
         self.find_manifest_file(module_name)
             .await
@@ -339,9 +339,9 @@ impl Registry {
 
     pub async fn is_module_enabled(
         &self,
-        module_name: impl AsRef<str>,
+        module_name: &ModuleName,
     ) -> Result<bool, IsModuleEnabledError> {
-        let path = self.enable_dir.join(module_name.as_ref());
+        let path = self.enable_dir.join(module_name.as_str());
 
         tokio::fs::symlink_metadata(&path)
             .await
@@ -355,13 +355,7 @@ impl Registry {
             })
     }
 
-    pub async fn enable_module(&self, module_name: impl AsRef<str>) -> Result<(), EnableError> {
-        let module_name = module_name.as_ref();
-
-        if !is_valid_name(module_name) {
-            return Err(EnableError::InvalidName(module_name.into()));
-        }
-
+    pub async fn enable_module(&self, module_name: &ModuleName) -> Result<(), EnableError> {
         self.migrate_legacy_manifest(module_name).await;
 
         let module_dir = self.module_dir(module_name);
@@ -371,7 +365,7 @@ impl Registry {
         }
 
         let target_path = self.enable_target(module_name);
-        let src_path = self.enable_dir.join(module_name);
+        let src_path = self.enable_dir.join(module_name.as_str());
 
         match create_symlink(&target_path, &src_path, true).await {
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
@@ -385,14 +379,8 @@ impl Registry {
         .map_err(Into::into)
     }
 
-    pub async fn disable_module(&self, module_name: impl AsRef<str>) -> Result<(), DisableError> {
-        let module_name = module_name.as_ref();
-
-        if !is_valid_name(module_name) {
-            return Err(DisableError::InvalidName(module_name.into()));
-        }
-
-        let path = self.enable_dir.join(module_name);
+    pub async fn disable_module(&self, module_name: &ModuleName) -> Result<(), DisableError> {
+        let path = self.enable_dir.join(module_name.as_str());
 
         let result = match tokio::fs::remove_file(&path).await {
             // on Windows a symlink to a directory has to be removed as a directory
@@ -412,7 +400,7 @@ impl Registry {
     }
 
     /// The path that the entry in [`Self::enable_dir`] points to for `module_name`.
-    fn enable_target(&self, module_name: &str) -> PathBuf {
+    fn enable_target(&self, module_name: &ModuleName) -> PathBuf {
         if self
             .install_dir
             .parent()
@@ -422,7 +410,7 @@ impl Registry {
             // install_dir and enable_dir share a parent, so point relatively: ../installed/<name>
             PathBuf::from("..")
                 .join(self.install_dir.file_name().unwrap())
-                .join(module_name)
+                .join(module_name.as_str())
         } else {
             self.module_dir(module_name)
         }
@@ -430,11 +418,9 @@ impl Registry {
 
     async fn find_manifest_file(
         &self,
-        module_name: impl AsRef<str>,
+        module_name: &ModuleName,
     ) -> Result<Option<PathBuf>, FindManifestError> {
-        let path = self
-            .module_dir(module_name.as_ref())
-            .join(MANIFEST_FILE_NAME);
+        let path = self.module_dir(module_name).join(MANIFEST_FILE_NAME);
 
         match tokio::fs::try_exists(&path).await {
             Ok(true) => Ok(Some(path)),
@@ -445,7 +431,7 @@ impl Registry {
 
     /// Moves the manifest of `module_name` into its own directory, if it is still a file directly
     /// in the install directory: `~/.asimov/modules/installed/<name>.{json,yaml,yml}`.
-    async fn migrate_legacy_manifest(&self, module_name: &str) {
+    async fn migrate_legacy_manifest(&self, module_name: &ModuleName) {
         let files = [
             format!("{module_name}.json"),
             format!("{module_name}.yaml"),
@@ -462,7 +448,7 @@ impl Registry {
         }
     }
 
-    async fn move_legacy_manifest(&self, module_name: &str, path: &Path) {
+    async fn move_legacy_manifest(&self, module_name: &ModuleName, path: &Path) {
         let module_dir = self.module_dir(module_name);
         let dst = module_dir.join(MANIFEST_FILE_NAME);
 
@@ -510,7 +496,7 @@ impl Registry {
 
         // the entry in `enable_dir` still points at the manifest file that just moved
         if self.is_module_enabled(module_name).await.unwrap_or(false) {
-            let path = self.enable_dir.join(module_name);
+            let path = self.enable_dir.join(module_name.as_str());
 
             let _ = tokio::fs::remove_file(&path).await;
             let _ = create_symlink(&self.enable_target(module_name), &path, true).await;
@@ -532,10 +518,9 @@ async fn create_symlink(target: &Path, link: &Path, target_is_dir: bool) -> io::
     }
 }
 
-/// Module and program names are joined onto the registry's directories, so a name that is not a
-/// plain path component could reach files outside of them. Mirrors the names that
-/// `asimov-module-kit` allows a module to be created with.
-fn is_valid_name(name: &str) -> bool {
+/// Program names are joined onto [`Registry::exec_dir`], so a name that is not a plain path
+/// component could reach files outside of it. Module names carry the same guarantee in their type.
+fn is_valid_program_name(name: &str) -> bool {
     !name.is_empty()
         && name.as_bytes()[0].is_ascii_alphanumeric()
         && !name.ends_with('-')

--- a/rust/lib/asimov-registry/src/registry.rs
+++ b/rust/lib/asimov-registry/src/registry.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use alloc::{format, string::String, vec::Vec};
+use alloc::{collections::BTreeSet, format, string::String, vec::Vec};
 use asimov_module::InstalledModuleManifest;
 use std::path::{Path, PathBuf};
 use tokio::io;
@@ -11,8 +11,6 @@ use error::*;
 pub const MANIFEST_FILE_NAME: &str = "manifest.json";
 pub const README_FILE_PATH: &str = "doc/README.md";
 pub const BIN_DIR_NAME: &str = "bin";
-
-const MANIFEST_FILE_NAMES: [&str; 3] = [MANIFEST_FILE_NAME, "manifest.yaml", "manifest.yml"];
 
 #[derive(Clone, Debug, Default, bon::Builder)]
 pub struct Options {}
@@ -212,11 +210,9 @@ impl Registry {
     pub async fn installed_modules(
         &self,
     ) -> Result<Vec<InstalledModuleManifest>, InstalledModulesError> {
-        self.migrate_legacy_manifests().await;
-
         let installed_dir = &self.install_dir;
 
-        let mut modules = Vec::new();
+        let mut module_names = BTreeSet::new();
 
         let mut read_dir = tokio::fs::read_dir(&installed_dir)
             .await
@@ -227,22 +223,36 @@ impl Registry {
             .await
             .map_err(|e| InstalledModulesError::DirIo(installed_dir.clone(), e))?
         {
-            let path = entry.path();
+            let Ok(name) = entry.file_name().into_string() else {
+                continue;
+            };
 
-            if !tokio::fs::metadata(&path)
+            if tokio::fs::metadata(entry.path())
                 .await
                 .map(|md| md.is_dir())
                 .unwrap_or(false)
             {
+                module_names.insert(name);
+            } else if let Some(module_name) = manifest_file_module_name(Path::new(&name)) {
+                self.migrate_legacy_manifest(module_name).await;
+
+                module_names.insert(module_name.into());
+            }
+        }
+
+        module_names.extend(self.migrate_legacy_modules_dir().await);
+
+        let mut modules = Vec::new();
+
+        for module_name in module_names {
+            let manifest_path = self.module_dir(module_name).join(MANIFEST_FILE_NAME);
+
+            if !tokio::fs::try_exists(&manifest_path)
+                .await
+                .map_err(|e| InstalledModulesError::DirIo(manifest_path.clone(), e))?
+            {
                 continue;
             }
-
-            let Some(manifest_path) = find_manifest_in_dir(&path)
-                .await
-                .map_err(|e| InstalledModulesError::DirIo(path.clone(), e))?
-            else {
-                continue;
-            };
 
             let manifest = read_manifest(&manifest_path)
                 .await
@@ -270,9 +280,11 @@ impl Registry {
             .await
             .map_err(|e| EnabledModulesError::DirIo(enabled_dir.clone(), e))?
         {
-            let path = entry.path();
+            let Ok(module_name) = entry.file_name().into_string() else {
+                continue;
+            };
 
-            if !tokio::fs::symlink_metadata(&path)
+            if !tokio::fs::symlink_metadata(entry.path())
                 .await
                 .map(|md| md.is_symlink())
                 .unwrap_or(false)
@@ -280,33 +292,23 @@ impl Registry {
                 continue;
             }
 
-            let manifest_path = tokio::fs::read_link(&path)
-                .await
-                .map_err(|e| EnabledModulesError::LinkIo(path.clone(), e))?;
+            let manifest_path = self.module_dir(&module_name).join(MANIFEST_FILE_NAME);
 
-            let manifest_path = if manifest_path.is_absolute() {
-                manifest_path
-            } else {
-                enabled_dir.join(&manifest_path)
-            };
+            // the entry may still point at a manifest file rather than a module directory
+            if !tokio::fs::try_exists(&manifest_path).await.unwrap_or(false) {
+                self.migrate_legacy_manifest(&module_name).await;
+            }
 
-            let manifest_path = if tokio::fs::metadata(&manifest_path)
+            if !tokio::fs::try_exists(&manifest_path)
                 .await
-                .map(|md| md.is_dir())
-                .unwrap_or(false)
+                .map_err(|e| EnabledModulesError::DirIo(manifest_path.clone(), e))?
             {
-                match find_manifest_in_dir(&manifest_path).await {
-                    Ok(Some(manifest_path)) => manifest_path,
-                    Ok(None) => continue,
-                    Err(e) => return Err(EnabledModulesError::DirIo(manifest_path, e)),
-                }
-            } else {
-                manifest_path
-            };
+                continue;
+            }
 
             let manifest = read_manifest(&manifest_path)
                 .await
-                .map_err(|e| EnabledModulesError::ReadManifestError(path, e))?;
+                .map_err(|e| EnabledModulesError::ReadManifestError(manifest_path, e))?;
 
             modules.push(manifest)
         }
@@ -412,11 +414,15 @@ impl Registry {
         &self,
         module_name: impl AsRef<str>,
     ) -> Result<Option<PathBuf>, FindManifestError> {
-        let module_dir = self.module_dir(module_name.as_ref());
+        let path = self
+            .module_dir(module_name.as_ref())
+            .join(MANIFEST_FILE_NAME);
 
-        find_manifest_in_dir(&module_dir)
-            .await
-            .map_err(|err| FindManifestError(module_dir, err))
+        match tokio::fs::try_exists(&path).await {
+            Ok(true) => Ok(Some(path)),
+            Ok(false) => Ok(None),
+            Err(err) => Err(FindManifestError(path, err)),
+        }
     }
 
     /// The directories that manifests may reside in directly, from before manifests were installed
@@ -447,42 +453,61 @@ impl Registry {
         }
     }
 
-    /// Like [`Self::migrate_legacy_manifest`], but for every module found in a legacy location.
-    async fn migrate_legacy_manifests(&self) {
-        for dir in self.legacy_dirs() {
-            let Ok(mut read_dir) = tokio::fs::read_dir(dir).await else {
+    /// Like [`Self::migrate_legacy_manifest`], but for every manifest in [`Self::legacy_modules_dir`],
+    /// which is not otherwise iterated over. Returns the names of the modules found there.
+    async fn migrate_legacy_modules_dir(&self) -> Vec<String> {
+        let mut module_names = Vec::new();
+
+        let Some(dir) = self.legacy_modules_dir.as_deref() else {
+            return module_names;
+        };
+
+        let Ok(mut read_dir) = tokio::fs::read_dir(dir).await else {
+            return module_names;
+        };
+
+        while let Ok(Some(entry)) = read_dir.next_entry().await {
+            let path = entry.path();
+
+            let Some(module_name) = manifest_file_module_name(&path) else {
                 continue;
             };
 
-            while let Ok(Some(entry)) = read_dir.next_entry().await {
-                let path = entry.path();
+            if tokio::fs::metadata(&path)
+                .await
+                .map(|md| md.is_file())
+                .unwrap_or(false)
+            {
+                tracing::debug!(?path, "found a legacy manifest file, migrating...");
 
-                let Some(module_name) = manifest_file_module_name(&path) else {
-                    continue;
-                };
+                self.move_legacy_manifest(module_name, &path).await;
 
-                if tokio::fs::metadata(&path)
-                    .await
-                    .map(|md| md.is_file())
-                    .unwrap_or(false)
-                {
-                    tracing::debug!(?path, "found a legacy manifest file, migrating...");
-
-                    self.move_legacy_manifest(module_name, &path).await;
-                }
+                module_names.push(module_name.into());
             }
         }
+
+        module_names
     }
 
     async fn move_legacy_manifest(&self, module_name: &str, path: &Path) {
         let module_dir = self.module_dir(module_name);
-
-        let extension = path.extension().unwrap_or_else(|| "json".as_ref());
-        let dst = module_dir.join("manifest").with_extension(extension);
+        let dst = module_dir.join(MANIFEST_FILE_NAME);
 
         let result = async {
+            let content = tokio::fs::read(path).await?;
+
+            let manifest: InstalledModuleManifest =
+                match path.extension().and_then(|ext| ext.to_str()) {
+                    Some("yaml") | Some("yml") => {
+                        serde_yaml_ng::from_slice(&content).map_err(io::Error::other)?
+                    },
+                    _ => serde_json::from_slice(&content).map_err(io::Error::other)?,
+                };
+            let content = serde_json::to_vec(&manifest).map_err(io::Error::other)?;
+
             tokio::fs::create_dir_all(&module_dir).await?;
-            tokio::fs::rename(path, &dst).await
+            tokio::fs::write(&dst, content).await?;
+            tokio::fs::remove_file(path).await
         }
         .await;
 
@@ -520,19 +545,6 @@ async fn create_symlink(target: &Path, link: &Path, target_is_dir: bool) -> io::
     }
 }
 
-async fn find_manifest_in_dir(module_dir: &Path) -> io::Result<Option<PathBuf>> {
-    for file in MANIFEST_FILE_NAMES {
-        let path = module_dir.join(file);
-        match tokio::fs::try_exists(&path).await {
-            Ok(exists) if exists => return Ok(Some(path)),
-            Err(err) if err.kind() != io::ErrorKind::NotFound => return Err(err),
-            _ => continue,
-        }
-    }
-
-    Ok(None)
-}
-
 fn manifest_file_module_name(path: &Path) -> Option<&str> {
     match path.extension().and_then(|ext| ext.to_str()) {
         Some("json") | Some("yaml") | Some("yml") => {
@@ -545,24 +557,11 @@ fn manifest_file_module_name(path: &Path) -> Option<&str> {
 async fn read_manifest(
     path: impl AsRef<Path>,
 ) -> Result<InstalledModuleManifest, ReadManifestError> {
-    let manifest = match path.as_ref().extension().and_then(|ext| ext.to_str()) {
-        Some("yaml") | Some("yml") => {
-            let content = tokio::fs::read(&path)
-                .await
-                .map_err(ReadManifestError::InstalledManifestIo)?;
+    let content = tokio::fs::read(&path)
+        .await
+        .map_err(ReadManifestError::InstalledManifestIo)?;
 
-            serde_yaml_ng::from_slice::<'_, InstalledModuleManifest>(&content)?
-        },
-        Some("json") => {
-            let content = tokio::fs::read(&path)
-                .await
-                .map_err(ReadManifestError::InstalledManifestIo)?;
-
-            serde_json::from_slice::<'_, InstalledModuleManifest>(&content)?
-        },
-        ext => Err(ReadManifestError::UnknownManifestFormat(
-            ext.map(Into::into),
-        ))?,
-    };
-    Ok(manifest)
+    Ok(serde_json::from_slice::<'_, InstalledModuleManifest>(
+        &content,
+    )?)
 }

--- a/rust/lib/asimov-registry/src/registry.rs
+++ b/rust/lib/asimov-registry/src/registry.rs
@@ -87,6 +87,10 @@ impl Registry {
     ) -> Result<(), AddModuleError> {
         let module_name = module_name.as_ref();
 
+        if !is_valid_name(module_name) {
+            return Err(AddModuleError::InvalidName(module_name.into()));
+        }
+
         if self.is_module_installed(module_name).await.unwrap_or(false) {
             return Err(AddModuleError::AlreadyInstalled);
         }
@@ -163,6 +167,10 @@ impl Registry {
         &self,
         module_name: impl AsRef<str>,
     ) -> Result<(), RemoveModuleError> {
+        if !is_valid_name(module_name.as_ref()) {
+            return Err(RemoveModuleError::InvalidName(module_name.as_ref().into()));
+        }
+
         self.migrate_legacy_manifest(module_name.as_ref()).await;
 
         if self.find_manifest_file(&module_name).await?.is_none() {
@@ -193,13 +201,19 @@ impl Registry {
     }
 
     pub async fn remove_binary(&self, name: impl AsRef<str>) -> Result<(), RemoveBinaryError> {
-        let binary_path = self.exec_dir.join(name.as_ref());
+        let name = name.as_ref();
+
+        if !is_valid_name(name) {
+            return Err(RemoveBinaryError::InvalidName(name.into()));
+        }
+
+        let binary_path = self.exec_dir.join(name);
 
         tokio::fs::remove_file(&binary_path).await.or_else(|e| {
             if e.kind() == io::ErrorKind::NotFound {
                 Ok(())
             } else {
-                Err(RemoveBinaryError(e))
+                Err(RemoveBinaryError::Io(e))
             }
         })
     }
@@ -344,6 +358,10 @@ impl Registry {
     pub async fn enable_module(&self, module_name: impl AsRef<str>) -> Result<(), EnableError> {
         let module_name = module_name.as_ref();
 
+        if !is_valid_name(module_name) {
+            return Err(EnableError::InvalidName(module_name.into()));
+        }
+
         self.migrate_legacy_manifest(module_name).await;
 
         let module_dir = self.module_dir(module_name);
@@ -368,12 +386,17 @@ impl Registry {
     }
 
     pub async fn disable_module(&self, module_name: impl AsRef<str>) -> Result<(), DisableError> {
-        let path = self.enable_dir.join(module_name.as_ref());
+        let module_name = module_name.as_ref();
+
+        if !is_valid_name(module_name) {
+            return Err(DisableError::InvalidName(module_name.into()));
+        }
+
+        let path = self.enable_dir.join(module_name);
 
         let result = match tokio::fs::remove_file(&path).await {
-            Err(err) if err.kind() != io::ErrorKind::NotFound => {
-                tokio::fs::remove_dir(&path).await.or(Err(err))
-            },
+            // on Windows a symlink to a directory has to be removed as a directory
+            Err(err) if err.kind() != io::ErrorKind::NotFound => tokio::fs::remove_dir(&path).await,
             result => result,
         };
 
@@ -507,6 +530,18 @@ async fn create_symlink(target: &Path, link: &Path, target_is_dir: bool) -> io::
     } else {
         tokio::fs::symlink_file(target, link).await
     }
+}
+
+/// Module and program names are joined onto the registry's directories, so a name that is not a
+/// plain path component could reach files outside of them. Mirrors the names that
+/// `asimov-module-kit` allows a module to be created with.
+fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.as_bytes()[0].is_ascii_alphanumeric()
+        && !name.ends_with('-')
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
 }
 
 fn manifest_file_module_name(path: &Path) -> Option<&str> {

--- a/rust/lib/asimov-registry/src/registry.rs
+++ b/rust/lib/asimov-registry/src/registry.rs
@@ -8,16 +8,25 @@ use tokio::io;
 pub mod error;
 use error::*;
 
+pub const MANIFEST_FILE_NAME: &str = "manifest.json";
+pub const README_FILE_PATH: &str = "doc/README.md";
+pub const BIN_DIR_NAME: &str = "bin";
+
+const MANIFEST_FILE_NAMES: [&str; 3] = [MANIFEST_FILE_NAME, "manifest.yaml", "manifest.yml"];
+
 #[derive(Clone, Debug, bon::Builder)]
 pub struct Options {
     /// Controls whether to search for module manifests from a legacy location.
-    /// The legacy (previous) location by default is `~/.asimov/modules/*.yaml`.
+    /// The legacy (previous) locations by default are `~/.asimov/modules/*.yaml`
+    /// and `~/.asimov/modules/installed/*.{yaml,json}`.
     #[builder(default = true)]
     pub search_legacy_path: bool,
 
     /// Controls whether to automatically move module manifests from a legacy location.
-    /// The legacy (previous) location by default is `~/.asimov/modules/*.yaml`.
-    /// The new and current location by default is `~/.asimov/modules/installed/*.{yaml,json}`.
+    /// The legacy (previous) locations by default are `~/.asimov/modules/*.yaml`
+    /// and `~/.asimov/modules/installed/*.{yaml,json}`.
+    /// The new and current location by default is
+    /// `~/.asimov/modules/installed/<name>/manifest.json`.
     #[builder(default = true)]
     pub auto_migrate_legacy_path: bool,
 }
@@ -96,6 +105,10 @@ impl Registry {
         Ok(())
     }
 
+    pub fn module_dir(&self, module_name: impl AsRef<str>) -> PathBuf {
+        self.install_dir.join(module_name.as_ref())
+    }
+
     pub async fn add_manifest(
         &self,
         manifest: InstalledModuleManifest,
@@ -106,7 +119,13 @@ impl Registry {
             return Err(AddManifestError::AlreadyInstalled);
         }
 
-        let manifest_path = self.install_dir.join(module_name).with_extension("json");
+        let module_dir = self.module_dir(module_name);
+
+        tokio::fs::create_dir_all(&module_dir)
+            .await
+            .map_err(|e| AddManifestError::CreateModuleDir(module_dir.clone(), e))?;
+
+        let manifest_path = module_dir.join(MANIFEST_FILE_NAME);
 
         let serialized = serde_json::to_vec_pretty(&manifest).map_err(SerializeError::Json)?;
 
@@ -126,6 +145,36 @@ impl Registry {
         read_manifest(path).await.map_err(Into::into)
     }
 
+    pub async fn add_readme(
+        &self,
+        module_name: impl AsRef<str>,
+        content: impl AsRef<[u8]>,
+    ) -> Result<(), AddReadmeError> {
+        let readme_path = self.module_dir(module_name).join(README_FILE_PATH);
+        let doc_dir = readme_path.parent().unwrap();
+
+        tokio::fs::create_dir_all(doc_dir)
+            .await
+            .map_err(|e| AddReadmeError::CreateDocDir(doc_dir.into(), e))?;
+
+        tokio::fs::write(&readme_path, content)
+            .await
+            .map_err(|e| AddReadmeError::WriteReadme(readme_path, e))
+    }
+
+    pub async fn read_readme(
+        &self,
+        module_name: impl AsRef<str>,
+    ) -> Result<Option<String>, ReadReadmeError> {
+        let readme_path = self.module_dir(module_name).join(README_FILE_PATH);
+
+        match tokio::fs::read_to_string(&readme_path).await {
+            Ok(content) => Ok(Some(content)),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(ReadReadmeError(readme_path, err)),
+        }
+    }
+
     pub async fn module_version(
         &self,
         module_name: impl AsRef<str>,
@@ -136,33 +185,47 @@ impl Registry {
             .map_err(Into::into)
     }
 
-    pub async fn remove_manifest(
+    /// Removes a module's entire installation directory.
+    pub async fn remove_module(
         &self,
         module_name: impl AsRef<str>,
-    ) -> Result<(), RemoveManifestError> {
+    ) -> Result<(), RemoveModuleError> {
         let manifest_path = self
             .find_manifest_file(&module_name)
             .await?
-            .ok_or(RemoveManifestError::NotInstalled)?;
+            .ok_or(RemoveModuleError::NotInstalled)?;
 
-        tokio::fs::remove_file(&manifest_path)
-            .await
-            .map_err(|e| RemoveManifestError::RemoveManifest(manifest_path, e))
+        let module_dir = self.module_dir(&module_name);
+
+        if manifest_path.starts_with(&module_dir) {
+            tokio::fs::remove_dir_all(&module_dir)
+                .await
+                .map_err(|e| RemoveModuleError::RemoveModuleDir(module_dir, e))
+        } else {
+            tokio::fs::remove_file(&manifest_path)
+                .await
+                .map_err(|e| RemoveModuleError::RemoveManifest(manifest_path, e))
+        }
     }
 
+    /// Anything already occupying the symlink's place, such as a binary
+    /// installed in a previous layout, is replaced.
     pub async fn add_binary(
         &self,
-        name: impl AsRef<str>,
+        module_name: impl AsRef<str>,
+        program_name: impl AsRef<str>,
         path: impl AsRef<Path>,
     ) -> Result<(), AddBinaryError> {
-        let source_path = path.as_ref();
-        let target_path = self.exec_dir.join(name.as_ref());
+        let program_name = program_name.as_ref();
+        let bin_dir = self.module_dir(module_name).join(BIN_DIR_NAME);
 
-        if tokio::fs::try_exists(&target_path).await.unwrap_or(false) {
-            return Err(AddBinaryError::AlreadyExists);
-        }
+        tokio::fs::create_dir_all(&bin_dir)
+            .await
+            .map_err(|e| AddBinaryError::CreateBinDir(bin_dir.clone(), e))?;
 
-        tokio::fs::copy(source_path, &target_path)
+        let binary_path = bin_dir.join(program_name);
+
+        tokio::fs::copy(path.as_ref(), &binary_path)
             .await
             .map_err(AddBinaryError::Copy)?;
 
@@ -173,14 +236,31 @@ impl Registry {
             use std::os::unix::fs::PermissionsExt;
 
             let permissions = Permissions::from_mode(0o755);
-            tokio::fs::set_permissions(&target_path, permissions)
+            tokio::fs::set_permissions(&binary_path, permissions)
                 .await
                 .map_err(AddBinaryError::MakeExecutable)?;
         }
 
-        Ok(())
+        // e.g. `../modules/installed/foo/bin/asimov-foo-fetcher`
+        let target_path = match self
+            .exec_dir
+            .parent()
+            .and_then(|parent| binary_path.strip_prefix(parent).ok())
+        {
+            Some(suffix) => PathBuf::from("..").join(suffix),
+            None => binary_path,
+        };
+
+        let link_path = self.exec_dir.join(program_name);
+        let _ = self.remove_binary(program_name).await;
+
+        create_symlink(&target_path, &link_path, false)
+            .await
+            .map_err(AddBinaryError::Symlink)
     }
 
+    /// Removes only the symlink; the program itself is removed with the module's
+    /// own directory.
     pub async fn remove_binary(&self, name: impl AsRef<str>) -> Result<(), RemoveBinaryError> {
         let binary_path = self.exec_dir.join(name.as_ref());
 
@@ -214,7 +294,7 @@ impl Registry {
                     continue;
                 }
 
-                let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+                let Some(module_name) = manifest_file_module_name(&path) else {
                     continue;
                 };
 
@@ -222,14 +302,8 @@ impl Registry {
                     if self.options.auto_migrate_legacy_path {
                         tracing::debug!(?path, "found a legacy manifest file, migrating...");
 
-                        let dst = installed_dir.join(file_name);
-
-                        tokio::fs::rename(&path, &dst)
-                            .await
-                            .inspect_err(|e| {
-                                tracing::debug!(from = ?path, to = ?dst, "failed to migrate legacy manifest file: {e}")
-                            })
-                            .ok();
+                        // once migrated, the module is found by the scan below
+                        self.migrate_legacy_manifest(module_name, &path).await.ok();
                     } else {
                         modules.push(manifest);
                     }
@@ -248,19 +322,40 @@ impl Registry {
         {
             let path = entry.path();
 
-            if !tokio::fs::metadata(&path)
-                .await
-                .map(|md| md.is_file())
-                .unwrap_or(false)
-            {
+            let Ok(metadata) = tokio::fs::metadata(&path).await else {
                 continue;
+            };
+
+            if metadata.is_dir() {
+                let Some(manifest_path) = find_manifest_in_dir(&path)
+                    .await
+                    .map_err(|e| InstalledModulesError::DirIo(path.clone(), e))?
+                else {
+                    continue;
+                };
+
+                let manifest = read_manifest(&manifest_path)
+                    .await
+                    .map_err(|e| InstalledModulesError::ReadManifestError(manifest_path, e))?;
+
+                modules.push(manifest)
+            } else if metadata.is_file() {
+                let Some(module_name) = manifest_file_module_name(&path) else {
+                    continue;
+                };
+
+                let manifest = read_manifest(&path)
+                    .await
+                    .map_err(|e| InstalledModulesError::ReadManifestError(path.clone(), e))?;
+
+                if self.options.auto_migrate_legacy_path {
+                    tracing::debug!(?path, "found a legacy manifest file, migrating...");
+
+                    self.migrate_legacy_manifest(module_name, &path).await.ok();
+                }
+
+                modules.push(manifest)
             }
-
-            let manifest = read_manifest(&path)
-                .await
-                .map_err(|e| InstalledModulesError::ReadManifestError(path, e))?;
-
-            modules.push(manifest)
         }
 
         Ok(modules)
@@ -302,6 +397,20 @@ impl Registry {
                 enabled_dir.join(&manifest_path)
             };
 
+            let manifest_path = if tokio::fs::metadata(&manifest_path)
+                .await
+                .map(|md| md.is_dir())
+                .unwrap_or(false)
+            {
+                match find_manifest_in_dir(&manifest_path).await {
+                    Ok(Some(manifest_path)) => manifest_path,
+                    Ok(None) => continue,
+                    Err(e) => return Err(EnabledModulesError::DirIo(manifest_path, e)),
+                }
+            } else {
+                manifest_path
+            };
+
             let manifest = read_manifest(&manifest_path)
                 .await
                 .map_err(|e| EnabledModulesError::ReadManifestError(path, e))?;
@@ -341,63 +450,28 @@ impl Registry {
     }
 
     pub async fn enable_module(&self, module_name: impl AsRef<str>) -> Result<(), EnableError> {
-        let target_path = self
+        let manifest_path = self
             .find_manifest_file(&module_name)
             .await?
             .ok_or(EnableError::NotInstalled)?;
 
-        let target_path = if self
-            .install_dir
-            .parent()
-            .zip(self.enable_dir.parent())
-            .is_some_and(|(a, b)| a == b)
-        {
-            // This scope only runs if install_dir and enable_dir share the same parent directory.
-
-            if target_path.starts_with(&self.install_dir) {
-                // manifest is in installed directory: ../installed/manifest.json
-                std::path::PathBuf::from("..")
-                    .join(self.install_dir.file_name().unwrap())
-                    .join(target_path.file_name().unwrap())
-            } else {
-                // manifest is in legacy location: ../manifest.yaml
-                std::path::PathBuf::from("..").join(target_path.file_name().unwrap())
-            }
-        } else {
-            target_path
-        };
-
-        let src_path = self.enable_dir.join(module_name.as_ref());
-
-        #[cfg(unix)]
-        let fut = tokio::fs::symlink(&target_path, &src_path);
-
-        #[cfg(windows)]
-        let fut = tokio::fs::symlink_file(&target_path, &src_path);
-
-        match fut.await {
-            Ok(_) => Ok(()),
-            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
-                // disable and retry enabling one more time
-                let _ = self.disable_module(module_name).await;
-
-                #[cfg(unix)]
-                let fut = tokio::fs::symlink(&target_path, &src_path);
-
-                #[cfg(windows)]
-                let fut = tokio::fs::symlink_file(&target_path, &src_path);
-
-                fut.await.map_err(EnableError::Io)
-            },
-            Err(err) => Err(EnableError::Io(err)),
-        }
+        self.link_module(module_name.as_ref(), &manifest_path)
+            .await
+            .map_err(EnableError::Io)
     }
 
     pub async fn disable_module(&self, module_name: impl AsRef<str>) -> Result<(), DisableError> {
         let path = self.enable_dir.join(module_name.as_ref());
 
-        tokio::fs::remove_file(&path)
-            .await
+        let result = match tokio::fs::remove_file(&path).await {
+            // on Windows a symlink to a directory has to be removed as a directory
+            Err(err) if err.kind() != io::ErrorKind::NotFound => {
+                tokio::fs::remove_dir(&path).await.or(Err(err))
+            },
+            result => result,
+        };
+
+        result
             .or_else(|err| {
                 if err.kind() == io::ErrorKind::NotFound {
                     Ok(())
@@ -408,70 +482,176 @@ impl Registry {
             .map_err(Into::into)
     }
 
+    async fn link_module(&self, module_name: &str, manifest_path: &Path) -> io::Result<()> {
+        let module_dir = self.module_dir(module_name);
+
+        // a manifest in a legacy location has no directory to link to
+        let target_path = if manifest_path.starts_with(&module_dir) {
+            module_dir
+        } else {
+            manifest_path.into()
+        };
+        let target_is_dir = tokio::fs::metadata(&target_path)
+            .await
+            .map(|md| md.is_dir())
+            .unwrap_or(false);
+
+        let target_path = if self
+            .install_dir
+            .parent()
+            .zip(self.enable_dir.parent())
+            .is_some_and(|(a, b)| a == b)
+        {
+            // This scope only runs if install_dir and enable_dir share the same parent directory.
+
+            if target_path.starts_with(&self.install_dir) {
+                // module is in installed directory: ../installed/<name>
+                PathBuf::from("..")
+                    .join(self.install_dir.file_name().unwrap())
+                    .join(target_path.file_name().unwrap())
+            } else {
+                // manifest is in legacy location: ../<name>.yaml
+                PathBuf::from("..").join(target_path.file_name().unwrap())
+            }
+        } else {
+            target_path
+        };
+
+        let src_path = self.enable_dir.join(module_name);
+
+        match create_symlink(&target_path, &src_path, target_is_dir).await {
+            Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                // disable and retry enabling one more time
+                let _ = self.disable_module(module_name).await;
+
+                create_symlink(&target_path, &src_path, target_is_dir).await
+            },
+            result => result,
+        }
+    }
+
     async fn find_manifest_file(
         &self,
         module_name: impl AsRef<str>,
     ) -> Result<Option<PathBuf>, FindManifestError> {
-        use alloc::format;
+        use alloc::{format, vec};
 
-        let install_dir = &self.install_dir;
         let module_name = module_name.as_ref();
-        let files = [
-            format!("{module_name}.json"),
-            format!("{module_name}.yaml"),
-            format!("{module_name}.yml"),
-        ];
+        let module_dir = self.module_dir(module_name);
 
-        for file in &files {
-            let path = install_dir.join(file);
-            match tokio::fs::try_exists(&path).await {
-                Ok(exists) if exists => return Ok(Some(path)),
-                Err(err) if err.kind() != io::ErrorKind::NotFound => {
-                    return Err(FindManifestError(path, err));
-                },
-                _ => continue,
-            }
+        if let Some(path) = find_manifest_in_dir(&module_dir)
+            .await
+            .map_err(|err| FindManifestError(module_dir, err))?
+        {
+            return Ok(Some(path));
         }
 
         if !self.options.search_legacy_path {
             return Ok(None);
         }
 
-        let legacy_dir = install_dir
-            .parent()
-            .expect("should never panic, self.install_dir() has >=2 path segments");
-        for file in &files {
-            let path = legacy_dir.join(file);
-            match tokio::fs::try_exists(&path).await {
-                Ok(exists) if exists => {
-                    if self.options.auto_migrate_legacy_path {
+        let files = [
+            format!("{module_name}.json"),
+            format!("{module_name}.yaml"),
+            format!("{module_name}.yml"),
+        ];
+
+        // the previous layout was `installed/<name>.json`, the one before that
+        // `modules/<name>.yaml`
+        let mut legacy_dirs = vec![self.install_dir.clone()];
+        if let Some(parent) = self.install_dir.parent() {
+            legacy_dirs.push(parent.into());
+        }
+
+        for dir in &legacy_dirs {
+            for file in &files {
+                let path = dir.join(file);
+                match tokio::fs::try_exists(&path).await {
+                    Ok(exists) if exists => {
+                        if !self.options.auto_migrate_legacy_path {
+                            return Ok(Some(path));
+                        }
+
                         tracing::debug!(?path, "found a legacy manifest file, migrating...");
-                        let dst = install_dir.join(file);
-                        return Ok(tokio::fs::rename(&path, &dst)
-                            .await
-                            .inspect_err(|err| {
-                                tracing::debug!(
-                                    from = ?path,
-                                    to = ?dst,
-                                    ?err,
-                                    "tried to move module manifest from legacy path but failed"
-                                )
-                            })
-                            .is_ok()
-                            .then_some(dst)
-                            .or(Some(path)));
-                    } else {
-                        return Ok(Some(path));
-                    }
-                },
-                Err(err) if err.kind() != io::ErrorKind::NotFound => {
-                    return Err(FindManifestError(path, err));
-                },
-                _ => continue,
+
+                        return Ok(Some(
+                            self.migrate_legacy_manifest(module_name, &path)
+                                .await
+                                .unwrap_or(path),
+                        ));
+                    },
+                    Err(err) if err.kind() != io::ErrorKind::NotFound => {
+                        return Err(FindManifestError(path, err));
+                    },
+                    _ => continue,
+                }
             }
         }
 
         Ok(None)
+    }
+
+    async fn migrate_legacy_manifest(&self, module_name: &str, path: &Path) -> io::Result<PathBuf> {
+        let module_dir = self.module_dir(module_name);
+
+        tokio::fs::create_dir_all(&module_dir).await?;
+
+        let extension = path.extension().unwrap_or_else(|| "json".as_ref());
+        let dst = module_dir.join("manifest").with_extension(extension);
+
+        tokio::fs::rename(path, &dst).await.inspect_err(|err| {
+            tracing::debug!(
+                from = ?path,
+                to = ?dst,
+                ?err,
+                "tried to move module manifest from legacy path but failed"
+            )
+        })?;
+
+        // an enabled module's symlink now points at the manifest's old location
+        if self.is_module_enabled(module_name).await.unwrap_or(false) {
+            let _ = self.disable_module(module_name).await;
+            let _ = self.link_module(module_name, &dst).await;
+        }
+
+        Ok(dst)
+    }
+}
+
+#[cfg(unix)]
+async fn create_symlink(target: &Path, link: &Path, _target_is_dir: bool) -> io::Result<()> {
+    tokio::fs::symlink(target, link).await
+}
+
+#[cfg(windows)]
+async fn create_symlink(target: &Path, link: &Path, target_is_dir: bool) -> io::Result<()> {
+    if target_is_dir {
+        tokio::fs::symlink_dir(target, link).await
+    } else {
+        tokio::fs::symlink_file(target, link).await
+    }
+}
+
+async fn find_manifest_in_dir(module_dir: &Path) -> io::Result<Option<PathBuf>> {
+    for file in MANIFEST_FILE_NAMES {
+        let path = module_dir.join(file);
+        match tokio::fs::try_exists(&path).await {
+            Ok(exists) if exists => return Ok(Some(path)),
+            Err(err) if err.kind() != io::ErrorKind::NotFound => return Err(err),
+            _ => continue,
+        }
+    }
+
+    Ok(None)
+}
+
+/// e.g. `foo` for `installed/foo.json`.
+fn manifest_file_module_name(path: &Path) -> Option<&str> {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("json") | Some("yaml") | Some("yml") => {
+            path.file_stem().and_then(|name| name.to_str())
+        },
+        _ => None,
     }
 }
 

--- a/rust/lib/asimov-registry/src/registry.rs
+++ b/rust/lib/asimov-registry/src/registry.rs
@@ -443,6 +443,20 @@ impl Registry {
         let module_dir = self.module_dir(module_name);
         let dst = module_dir.join(MANIFEST_FILE_NAME);
 
+        if tokio::fs::try_exists(&dst).await.unwrap_or(false) {
+            tracing::debug!(
+                legacy = ?path,
+                current = ?dst,
+                "module has both a legacy and a current manifest, removing the legacy one"
+            );
+
+            if let Err(err) = tokio::fs::remove_file(path).await {
+                tracing::warn!(?path, ?err, "failed to remove the legacy manifest file");
+            }
+
+            return;
+        }
+
         let result = async {
             let content = tokio::fs::read(path).await?;
 

--- a/rust/lib/asimov-registry/src/registry.rs
+++ b/rust/lib/asimov-registry/src/registry.rs
@@ -1,6 +1,6 @@
 // This is free and unencumbered software released into the public domain.
 
-use alloc::{string::String, vec::Vec};
+use alloc::{format, string::String, vec::Vec};
 use asimov_module::InstalledModuleManifest;
 use std::path::{Path, PathBuf};
 use tokio::io;
@@ -16,11 +16,6 @@ const MANIFEST_FILE_NAMES: [&str; 3] = [MANIFEST_FILE_NAME, "manifest.yaml", "ma
 
 #[derive(Clone, Debug, bon::Builder)]
 pub struct Options {
-    /// Controls whether to search for module manifests from a legacy location.
-    /// The legacy (previous) location by default is `~/.asimov/modules/*.yaml`.
-    #[builder(default = true)]
-    pub search_legacy_path: bool,
-
     /// Controls whether to automatically move module manifests from a legacy location.
     /// The legacy (previous) location by default is `~/.asimov/modules/*.yaml`.
     /// The new and current location by default is `~/.asimov/modules/installed/<name>/manifest.json`.
@@ -31,7 +26,6 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Self {
-            search_legacy_path: true,
             auto_migrate_legacy_path: true,
         }
     }
@@ -157,6 +151,8 @@ impl Registry {
         &self,
         module_name: impl AsRef<str>,
     ) -> Result<InstalledModuleManifest, ManifestError> {
+        self.migrate_legacy_manifest(module_name.as_ref()).await;
+
         let path = self
             .find_manifest_file(module_name)
             .await?
@@ -191,22 +187,17 @@ impl Registry {
         &self,
         module_name: impl AsRef<str>,
     ) -> Result<(), RemoveModuleError> {
-        let manifest_path = self
-            .find_manifest_file(&module_name)
-            .await?
-            .ok_or(RemoveModuleError::NotInstalled)?;
+        self.migrate_legacy_manifest(module_name.as_ref()).await;
+
+        if self.find_manifest_file(&module_name).await?.is_none() {
+            return Err(RemoveModuleError::NotInstalled);
+        }
 
         let module_dir = self.module_dir(&module_name);
 
-        if manifest_path.starts_with(&module_dir) {
-            tokio::fs::remove_dir_all(&module_dir)
-                .await
-                .map_err(|e| RemoveModuleError::RemoveModuleDir(module_dir, e))
-        } else {
-            tokio::fs::remove_file(&manifest_path)
-                .await
-                .map_err(|e| RemoveModuleError::RemoveManifest(manifest_path, e))
-        }
+        tokio::fs::remove_dir_all(&module_dir)
+            .await
+            .map_err(|e| RemoveModuleError::RemoveModuleDir(module_dir, e))
     }
 
     async fn add_binary(&self, program_name: &str, binary_path: &Path) -> io::Result<()> {
@@ -240,39 +231,11 @@ impl Registry {
     pub async fn installed_modules(
         &self,
     ) -> Result<Vec<InstalledModuleManifest>, InstalledModulesError> {
+        self.migrate_legacy_manifests().await;
+
         let installed_dir = &self.install_dir;
 
         let mut modules = Vec::new();
-
-        if (self.options.search_legacy_path || self.options.auto_migrate_legacy_path)
-            && let Some(modules_dir) = &self.legacy_modules_dir
-            && let Ok(mut read_dir) = tokio::fs::read_dir(modules_dir).await
-        {
-            while let Ok(Some(entry)) = read_dir.next_entry().await {
-                let path = entry.path();
-                if !tokio::fs::metadata(&path)
-                    .await
-                    .map(|md| md.is_file())
-                    .unwrap_or(false)
-                {
-                    continue;
-                }
-
-                let Some(module_name) = manifest_file_module_name(&path) else {
-                    continue;
-                };
-
-                if let Ok(manifest) = read_manifest(&path).await {
-                    if self.options.auto_migrate_legacy_path {
-                        tracing::debug!(?path, "found a legacy manifest file, migrating...");
-
-                        self.migrate_legacy_manifest(module_name, &path).await.ok();
-                    } else {
-                        modules.push(manifest);
-                    }
-                }
-            }
-        }
 
         let mut read_dir = tokio::fs::read_dir(&installed_dir)
             .await
@@ -285,40 +248,26 @@ impl Registry {
         {
             let path = entry.path();
 
-            let Ok(metadata) = tokio::fs::metadata(&path).await else {
+            if !tokio::fs::metadata(&path)
+                .await
+                .map(|md| md.is_dir())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
+            let Some(manifest_path) = find_manifest_in_dir(&path)
+                .await
+                .map_err(|e| InstalledModulesError::DirIo(path.clone(), e))?
+            else {
                 continue;
             };
 
-            if metadata.is_dir() {
-                let Some(manifest_path) = find_manifest_in_dir(&path)
-                    .await
-                    .map_err(|e| InstalledModulesError::DirIo(path.clone(), e))?
-                else {
-                    continue;
-                };
+            let manifest = read_manifest(&manifest_path)
+                .await
+                .map_err(|e| InstalledModulesError::ReadManifestError(manifest_path, e))?;
 
-                let manifest = read_manifest(&manifest_path)
-                    .await
-                    .map_err(|e| InstalledModulesError::ReadManifestError(manifest_path, e))?;
-
-                modules.push(manifest)
-            } else if metadata.is_file() {
-                let Some(module_name) = manifest_file_module_name(&path) else {
-                    continue;
-                };
-
-                let manifest = read_manifest(&path)
-                    .await
-                    .map_err(|e| InstalledModulesError::ReadManifestError(path.clone(), e))?;
-
-                if self.options.auto_migrate_legacy_path {
-                    tracing::debug!(?path, "found a legacy manifest file, migrating...");
-
-                    self.migrate_legacy_manifest(module_name, &path).await.ok();
-                }
-
-                modules.push(manifest)
-            }
+            modules.push(manifest)
         }
 
         Ok(modules)
@@ -388,6 +337,8 @@ impl Registry {
         &self,
         module_name: impl AsRef<str>,
     ) -> Result<bool, IsModuleInstalledError> {
+        self.migrate_legacy_manifest(module_name.as_ref()).await;
+
         self.find_manifest_file(module_name)
             .await
             .map(|path| path.is_some())
@@ -413,12 +364,13 @@ impl Registry {
     }
 
     pub async fn enable_module(&self, module_name: impl AsRef<str>) -> Result<(), EnableError> {
-        let manifest_path = self
-            .find_manifest_file(&module_name)
-            .await?
-            .ok_or(EnableError::NotInstalled)?;
+        self.migrate_legacy_manifest(module_name.as_ref()).await;
 
-        self.link_module(module_name.as_ref(), &manifest_path)
+        if self.find_manifest_file(&module_name).await?.is_none() {
+            return Err(EnableError::NotInstalled);
+        }
+
+        self.link_module(module_name.as_ref())
             .await
             .map_err(EnableError::Io)
     }
@@ -444,18 +396,8 @@ impl Registry {
             .map_err(Into::into)
     }
 
-    async fn link_module(&self, module_name: &str, manifest_path: &Path) -> io::Result<()> {
+    async fn link_module(&self, module_name: &str) -> io::Result<()> {
         let module_dir = self.module_dir(module_name);
-
-        let target_path = if manifest_path.starts_with(&module_dir) {
-            module_dir
-        } else {
-            manifest_path.into()
-        };
-        let target_is_dir = tokio::fs::metadata(&target_path)
-            .await
-            .map(|md| md.is_dir())
-            .unwrap_or(false);
 
         let target_path = if self
             .install_dir
@@ -463,29 +405,22 @@ impl Registry {
             .zip(self.enable_dir.parent())
             .is_some_and(|(a, b)| a == b)
         {
-            // This scope only runs if install_dir and enable_dir share the same parent directory.
-
-            if target_path.starts_with(&self.install_dir) {
-                // manifest is in installed directory: ../installed/<name>
-                PathBuf::from("..")
-                    .join(self.install_dir.file_name().unwrap())
-                    .join(target_path.file_name().unwrap())
-            } else {
-                // manifest is in legacy location: ../<name>.yaml
-                PathBuf::from("..").join(target_path.file_name().unwrap())
-            }
+            // install_dir and enable_dir share a parent, so link relatively: ../installed/<name>
+            PathBuf::from("..")
+                .join(self.install_dir.file_name().unwrap())
+                .join(module_name)
         } else {
-            target_path
+            module_dir
         };
 
         let src_path = self.enable_dir.join(module_name);
 
-        match create_symlink(&target_path, &src_path, target_is_dir).await {
+        match create_symlink(&target_path, &src_path, true).await {
             Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
                 // disable and retry enabling one more time
                 let _ = self.disable_module(module_name).await;
 
-                create_symlink(&target_path, &src_path, target_is_dir).await
+                create_symlink(&target_path, &src_path, true).await
             },
             result => result,
         }
@@ -495,20 +430,25 @@ impl Registry {
         &self,
         module_name: impl AsRef<str>,
     ) -> Result<Option<PathBuf>, FindManifestError> {
-        use alloc::{format, vec};
+        let module_dir = self.module_dir(module_name.as_ref());
 
-        let module_name = module_name.as_ref();
-        let module_dir = self.module_dir(module_name);
-
-        if let Some(path) = find_manifest_in_dir(&module_dir)
+        find_manifest_in_dir(&module_dir)
             .await
-            .map_err(|err| FindManifestError(module_dir, err))?
-        {
-            return Ok(Some(path));
-        }
+            .map_err(|err| FindManifestError(module_dir, err))
+    }
 
-        if !self.options.search_legacy_path {
-            return Ok(None);
+    /// The directories that manifests may reside in directly, from before manifests were installed
+    /// into a directory of their own: `~/.asimov/modules/installed/<name>.yaml`, and older still,
+    /// `~/.asimov/modules/<name>.yaml`.
+    fn legacy_dirs(&self) -> impl Iterator<Item = &Path> {
+        core::iter::once(self.install_dir.as_path()).chain(self.legacy_modules_dir.as_deref())
+    }
+
+    /// Moves the manifest of `module_name` into its own directory, if it is found in a legacy
+    /// location. Does nothing unless [`Options::auto_migrate_legacy_path`] is set.
+    async fn migrate_legacy_manifest(&self, module_name: &str) {
+        if !self.options.auto_migrate_legacy_path {
+            return;
         }
 
         let files = [
@@ -517,62 +457,75 @@ impl Registry {
             format!("{module_name}.yml"),
         ];
 
-        let mut legacy_dirs = vec![self.install_dir.clone()];
-        if let Some(parent) = self.install_dir.parent() {
-            legacy_dirs.push(parent.into());
-        }
-
-        for dir in &legacy_dirs {
+        for dir in self.legacy_dirs() {
             for file in &files {
                 let path = dir.join(file);
-                match tokio::fs::try_exists(&path).await {
-                    Ok(exists) if exists => {
-                        if !self.options.auto_migrate_legacy_path {
-                            return Ok(Some(path));
-                        }
+                if tokio::fs::try_exists(&path).await.unwrap_or(false) {
+                    tracing::debug!(?path, "found a legacy manifest file, migrating...");
 
-                        tracing::debug!(?path, "found a legacy manifest file, migrating...");
-
-                        return Ok(Some(
-                            self.migrate_legacy_manifest(module_name, &path)
-                                .await
-                                .unwrap_or(path),
-                        ));
-                    },
-                    Err(err) if err.kind() != io::ErrorKind::NotFound => {
-                        return Err(FindManifestError(path, err));
-                    },
-                    _ => continue,
+                    self.move_legacy_manifest(module_name, &path).await;
                 }
             }
         }
-
-        Ok(None)
     }
 
-    async fn migrate_legacy_manifest(&self, module_name: &str, path: &Path) -> io::Result<PathBuf> {
-        let module_dir = self.module_dir(module_name);
+    /// Like [`Self::migrate_legacy_manifest`], but for every module found in a legacy location.
+    async fn migrate_legacy_manifests(&self) {
+        if !self.options.auto_migrate_legacy_path {
+            return;
+        }
 
-        tokio::fs::create_dir_all(&module_dir).await?;
+        for dir in self.legacy_dirs() {
+            let Ok(mut read_dir) = tokio::fs::read_dir(dir).await else {
+                continue;
+            };
+
+            while let Ok(Some(entry)) = read_dir.next_entry().await {
+                let path = entry.path();
+
+                let Some(module_name) = manifest_file_module_name(&path) else {
+                    continue;
+                };
+
+                if tokio::fs::metadata(&path)
+                    .await
+                    .map(|md| md.is_file())
+                    .unwrap_or(false)
+                {
+                    tracing::debug!(?path, "found a legacy manifest file, migrating...");
+
+                    self.move_legacy_manifest(module_name, &path).await;
+                }
+            }
+        }
+    }
+
+    async fn move_legacy_manifest(&self, module_name: &str, path: &Path) {
+        let module_dir = self.module_dir(module_name);
 
         let extension = path.extension().unwrap_or_else(|| "json".as_ref());
         let dst = module_dir.join("manifest").with_extension(extension);
 
-        tokio::fs::rename(path, &dst).await.inspect_err(|err| {
+        let result = async {
+            tokio::fs::create_dir_all(&module_dir).await?;
+            tokio::fs::rename(path, &dst).await
+        }
+        .await;
+
+        if let Err(err) = result {
             tracing::debug!(
                 from = ?path,
                 to = ?dst,
                 ?err,
                 "tried to move module manifest from legacy path but failed"
-            )
-        })?;
+            );
+            return;
+        }
 
         if self.is_module_enabled(module_name).await.unwrap_or(false) {
             let _ = self.disable_module(module_name).await;
-            let _ = self.link_module(module_name, &dst).await;
+            let _ = self.link_module(module_name).await;
         }
-
-        Ok(dst)
     }
 }
 

--- a/rust/lib/asimov-registry/src/registry/error.rs
+++ b/rust/lib/asimov-registry/src/registry/error.rs
@@ -14,23 +14,15 @@ pub enum CreateFileTreeError {
 }
 
 #[derive(Debug, Error)]
-pub enum AddManifestError {
+pub enum AddModuleError {
     #[error("module is already installed")]
     AlreadyInstalled,
-    #[error("failed to create directory for installed module `{0}`: {1}")]
-    CreateModuleDir(PathBuf, #[source] io::Error),
-    #[error("failed to serialize module manifest: {0}")]
-    SerializeManifest(#[from] SerializeError),
-    #[error("failed to write module manifest to `{0}`: {1}")]
-    WriteManifest(PathBuf, #[source] io::Error),
-}
-
-#[derive(Debug, Error)]
-pub enum AddReadmeError {
-    #[error("failed to create directory for module documentation `{0}`: {1}")]
-    CreateDocDir(PathBuf, #[source] io::Error),
-    #[error("failed to write module README to `{0}`: {1}")]
-    WriteReadme(PathBuf, #[source] io::Error),
+    #[error("failed to install module from `{0}` to `{1}`: {2}")]
+    Install(PathBuf, PathBuf, #[source] io::Error),
+    #[error("failed to read directory of module binaries `{0}`: {1}")]
+    ReadBinDir(PathBuf, #[source] io::Error),
+    #[error("failed to add module binary `{0}`: {1}")]
+    AddBinary(String, #[source] io::Error),
 }
 
 #[derive(Debug, Error)]
@@ -61,19 +53,6 @@ pub enum RemoveModuleError {
     RemoveModuleDir(PathBuf, #[source] io::Error),
     #[error("failed to remove module manifest at `{0}`: {1}")]
     RemoveManifest(PathBuf, #[source] io::Error),
-}
-
-#[derive(Debug, Error)]
-pub enum AddBinaryError {
-    #[error("failed to create directory for module binaries `{0}`: {1}")]
-    CreateBinDir(PathBuf, #[source] io::Error),
-    #[error("failed to copy binary: {0}")]
-    Copy(#[source] io::Error),
-    #[cfg(unix)]
-    #[error("failed to make binary executable: {0}")]
-    MakeExecutable(#[source] io::Error),
-    #[error("failed to link binary: {0}")]
-    Symlink(#[source] io::Error),
 }
 
 #[derive(Debug, Error)]

--- a/rust/lib/asimov-registry/src/registry/error.rs
+++ b/rust/lib/asimov-registry/src/registry/error.rs
@@ -85,8 +85,6 @@ pub struct IsModuleEnabledError(#[from] io::Error);
 
 #[derive(Debug, Error)]
 pub enum EnableError {
-    #[error("error while searching for manifest file: {0}")]
-    FindManifest(#[from] FindManifestError),
     #[error("module is not installed")]
     NotInstalled,
     #[error("failed to enable module: {0}")]

--- a/rust/lib/asimov-registry/src/registry/error.rs
+++ b/rust/lib/asimov-registry/src/registry/error.rs
@@ -15,6 +15,8 @@ pub enum CreateFileTreeError {
 
 #[derive(Debug, Error)]
 pub enum AddModuleError {
+    #[error("invalid module name `{0}`")]
+    InvalidName(String),
     #[error("module is already installed")]
     AlreadyInstalled,
     #[error("failed to install module from `{0}` to `{1}`: {2}")]
@@ -45,6 +47,8 @@ pub struct ModuleVersionError(#[from] ManifestError);
 
 #[derive(Debug, Error)]
 pub enum RemoveModuleError {
+    #[error("invalid module name `{0}`")]
+    InvalidName(String),
     #[error("error while searching for manifest file: {0}")]
     FindManifest(#[from] FindManifestError),
     #[error("module is not installed")]
@@ -54,8 +58,12 @@ pub enum RemoveModuleError {
 }
 
 #[derive(Debug, Error)]
-#[error("failed to remove binary: {0}")]
-pub struct RemoveBinaryError(#[from] pub io::Error);
+pub enum RemoveBinaryError {
+    #[error("invalid program name `{0}`")]
+    InvalidName(String),
+    #[error("failed to remove binary: {0}")]
+    Io(#[from] io::Error),
+}
 
 #[derive(Debug, Error)]
 pub enum InstalledModulesError {
@@ -83,6 +91,8 @@ pub struct IsModuleEnabledError(#[from] io::Error);
 
 #[derive(Debug, Error)]
 pub enum EnableError {
+    #[error("invalid module name `{0}`")]
+    InvalidName(String),
     #[error("module is not installed")]
     NotInstalled,
     #[error("failed to enable module: {0}")]
@@ -90,8 +100,12 @@ pub enum EnableError {
 }
 
 #[derive(Debug, Error)]
-#[error("failed to disable module: {0}")]
-pub struct DisableError(#[from] pub io::Error);
+pub enum DisableError {
+    #[error("invalid module name `{0}`")]
+    InvalidName(String),
+    #[error("failed to disable module: {0}")]
+    Io(#[from] io::Error),
+}
 
 mod common {
     use super::*;

--- a/rust/lib/asimov-registry/src/registry/error.rs
+++ b/rust/lib/asimov-registry/src/registry/error.rs
@@ -51,8 +51,6 @@ pub enum RemoveModuleError {
     NotInstalled,
     #[error("failed to remove directory of installed module `{0}`: {1}")]
     RemoveModuleDir(PathBuf, #[source] io::Error),
-    #[error("failed to remove module manifest at `{0}`: {1}")]
-    RemoveManifest(PathBuf, #[source] io::Error),
 }
 
 #[derive(Debug, Error)]

--- a/rust/lib/asimov-registry/src/registry/error.rs
+++ b/rust/lib/asimov-registry/src/registry/error.rs
@@ -15,8 +15,6 @@ pub enum CreateFileTreeError {
 
 #[derive(Debug, Error)]
 pub enum AddModuleError {
-    #[error("invalid module name `{0}`")]
-    InvalidName(String),
     #[error("module is already installed")]
     AlreadyInstalled,
     #[error("failed to install module from `{0}` to `{1}`: {2}")]
@@ -47,8 +45,6 @@ pub struct ModuleVersionError(#[from] ManifestError);
 
 #[derive(Debug, Error)]
 pub enum RemoveModuleError {
-    #[error("invalid module name `{0}`")]
-    InvalidName(String),
     #[error("error while searching for manifest file: {0}")]
     FindManifest(#[from] FindManifestError),
     #[error("module is not installed")]
@@ -91,8 +87,6 @@ pub struct IsModuleEnabledError(#[from] io::Error);
 
 #[derive(Debug, Error)]
 pub enum EnableError {
-    #[error("invalid module name `{0}`")]
-    InvalidName(String),
     #[error("module is not installed")]
     NotInstalled,
     #[error("failed to enable module: {0}")]
@@ -100,12 +94,8 @@ pub enum EnableError {
 }
 
 #[derive(Debug, Error)]
-pub enum DisableError {
-    #[error("invalid module name `{0}`")]
-    InvalidName(String),
-    #[error("failed to disable module: {0}")]
-    Io(#[from] io::Error),
-}
+#[error("failed to disable module: {0}")]
+pub struct DisableError(#[from] pub io::Error);
 
 mod common {
     use super::*;

--- a/rust/lib/asimov-registry/src/registry/error.rs
+++ b/rust/lib/asimov-registry/src/registry/error.rs
@@ -17,11 +17,25 @@ pub enum CreateFileTreeError {
 pub enum AddManifestError {
     #[error("module is already installed")]
     AlreadyInstalled,
+    #[error("failed to create directory for installed module `{0}`: {1}")]
+    CreateModuleDir(PathBuf, #[source] io::Error),
     #[error("failed to serialize module manifest: {0}")]
     SerializeManifest(#[from] SerializeError),
     #[error("failed to write module manifest to `{0}`: {1}")]
     WriteManifest(PathBuf, #[source] io::Error),
 }
+
+#[derive(Debug, Error)]
+pub enum AddReadmeError {
+    #[error("failed to create directory for module documentation `{0}`: {1}")]
+    CreateDocDir(PathBuf, #[source] io::Error),
+    #[error("failed to write module README to `{0}`: {1}")]
+    WriteReadme(PathBuf, #[source] io::Error),
+}
+
+#[derive(Debug, Error)]
+#[error("failed to read module README at `{0}`: {1}")]
+pub struct ReadReadmeError(pub PathBuf, #[source] pub io::Error);
 
 #[derive(Debug, Error)]
 pub enum ManifestError {
@@ -38,24 +52,28 @@ pub enum ManifestError {
 pub struct ModuleVersionError(#[from] ManifestError);
 
 #[derive(Debug, Error)]
-pub enum RemoveManifestError {
+pub enum RemoveModuleError {
     #[error("error while searching for manifest file: {0}")]
     FindManifest(#[from] FindManifestError),
     #[error("module is not installed")]
     NotInstalled,
+    #[error("failed to remove directory of installed module `{0}`: {1}")]
+    RemoveModuleDir(PathBuf, #[source] io::Error),
     #[error("failed to remove module manifest at `{0}`: {1}")]
     RemoveManifest(PathBuf, #[source] io::Error),
 }
 
 #[derive(Debug, Error)]
 pub enum AddBinaryError {
-    #[error("binary already exists")]
-    AlreadyExists,
+    #[error("failed to create directory for module binaries `{0}`: {1}")]
+    CreateBinDir(PathBuf, #[source] io::Error),
     #[error("failed to copy binary: {0}")]
     Copy(#[source] io::Error),
     #[cfg(unix)]
     #[error("failed to make binary executable: {0}")]
     MakeExecutable(#[source] io::Error),
+    #[error("failed to link binary: {0}")]
+    Symlink(#[source] io::Error),
 }
 
 #[derive(Debug, Error)]

--- a/rust/lib/asimov-registry/src/registry/error.rs
+++ b/rust/lib/asimov-registry/src/registry/error.rs
@@ -69,8 +69,6 @@ pub enum InstalledModulesError {
 pub enum EnabledModulesError {
     #[error("failed to read directory for enabled modules `{0}`: {1}")]
     DirIo(PathBuf, #[source] io::Error),
-    #[error("failed to read symlink for enabled module at `{0}`: {1}")]
-    LinkIo(PathBuf, #[source] io::Error),
     #[error("failed to read manifest at `{0}`: {1}")]
     ReadManifestError(PathBuf, #[source] ReadManifestError),
 }
@@ -104,8 +102,6 @@ mod common {
         InstalledManifestIo(#[from] io::Error),
         #[error("failed to deserialize module manifest: {0}")]
         ManifestDeserialize(#[from] DeserializeError),
-        #[error("unknown manifest format: {}", .0.as_deref().unwrap_or("no file extension"))]
-        UnknownManifestFormat(Option<String>),
     }
 
     impl From<serde_json::Error> for ReadManifestError {

--- a/rust/lib/asimov-registry/tests/registry.rs
+++ b/rust/lib/asimov-registry/tests/registry.rs
@@ -193,6 +193,39 @@ pub async fn test_migrate_legacy_layout() {
 }
 
 #[tokio::test]
+pub async fn test_legacy_manifest_never_replaces_a_current_one() {
+    let manifest_json = |version: &str| {
+        let manifest = InstalledModuleManifest {
+            version: Some(version.into()),
+            manifest: serde_json::from_str(SAMPLE_MANIFEST).unwrap(),
+        };
+        serde_json::to_vec(&manifest).unwrap()
+    };
+
+    let base_dir = tempdir().unwrap();
+    let registry = Registry::new(base_dir.path(), Default::default());
+    registry.create_file_tree().await.unwrap();
+
+    let module_dir = base_dir.path().join("modules/installed/sample");
+    tokio::fs::create_dir(&module_dir).await.unwrap();
+    tokio::fs::write(module_dir.join("manifest.json"), manifest_json("2.0.0"))
+        .await
+        .unwrap();
+
+    let legacy_path = base_dir.path().join("modules/installed/sample.json");
+    tokio::fs::write(&legacy_path, manifest_json("0.1.7"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        registry.module_version("sample").await.unwrap().as_deref(),
+        Some("2.0.0")
+    );
+    assert!(!legacy_path.exists());
+    assert_eq!(registry.installed_modules().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
 pub async fn test_migrate_legacy_version() {
     let base_dir = tempdir().unwrap();
     let registry = Registry::new(base_dir.path(), Default::default());

--- a/rust/lib/asimov-registry/tests/registry.rs
+++ b/rust/lib/asimov-registry/tests/registry.rs
@@ -23,7 +23,7 @@ const SAMPLE_MANIFEST: &str = r#"{
 }
 "#;
 
-/// Manifests were YAML back when they lived directly in the modules directory.
+/// Manifests were YAML back when they lived directly in the install directory.
 const LEGACY_SAMPLE_MANIFEST: &str = r#"# See: https://asimov-specs.github.io/module-manifest/
 ---
 name: ipfs
@@ -165,33 +165,31 @@ pub async fn test_custom_registry() {
 }
 
 #[tokio::test]
-pub async fn test_migrate_legacy_layouts() {
-    for legacy_dir in ["modules", "modules/installed"] {
-        let base_dir = tempdir().unwrap();
-        let registry = Registry::new(base_dir.path(), Default::default());
-        registry.create_file_tree().await.unwrap();
+pub async fn test_migrate_legacy_layout() {
+    let base_dir = tempdir().unwrap();
+    let registry = Registry::new(base_dir.path(), Default::default());
+    registry.create_file_tree().await.unwrap();
 
-        let legacy_path = base_dir.path().join(legacy_dir).join("sample.yaml");
-        tokio::fs::write(&legacy_path, LEGACY_SAMPLE_MANIFEST)
-            .await
-            .unwrap();
+    let legacy_path = base_dir.path().join("modules/installed/sample.yaml");
+    tokio::fs::write(&legacy_path, LEGACY_SAMPLE_MANIFEST)
+        .await
+        .unwrap();
 
-        assert!(registry.is_module_installed("sample").await.unwrap());
-        registry.enable_module("sample").await.unwrap();
+    assert!(registry.is_module_installed("sample").await.unwrap());
+    registry.enable_module("sample").await.unwrap();
 
-        let module_dir = base_dir.path().join("modules/installed/sample");
-        assert!(!legacy_path.exists());
-        assert!(module_dir.join("manifest.json").is_file());
-        assert_eq!(registry.installed_modules().await.unwrap().len(), 1);
-        assert_eq!(registry.enabled_modules().await.unwrap().len(), 1);
+    let module_dir = base_dir.path().join("modules/installed/sample");
+    assert!(!legacy_path.exists());
+    assert!(module_dir.join("manifest.json").is_file());
+    assert_eq!(registry.installed_modules().await.unwrap().len(), 1);
+    assert_eq!(registry.enabled_modules().await.unwrap().len(), 1);
 
-        let enabled_path = base_dir.path().join("modules/enabled/sample");
-        let link_path = std::fs::read_link(&enabled_path).unwrap();
-        assert_eq!(
-            std::fs::canonicalize(enabled_path.parent().unwrap().join(link_path)).unwrap(),
-            std::fs::canonicalize(&module_dir).unwrap()
-        );
-    }
+    let enabled_path = base_dir.path().join("modules/enabled/sample");
+    let link_path = std::fs::read_link(&enabled_path).unwrap();
+    assert_eq!(
+        std::fs::canonicalize(enabled_path.parent().unwrap().join(link_path)).unwrap(),
+        std::fs::canonicalize(&module_dir).unwrap()
+    );
 }
 
 #[tokio::test]

--- a/rust/lib/asimov-registry/tests/registry.rs
+++ b/rust/lib/asimov-registry/tests/registry.rs
@@ -101,12 +101,16 @@ pub async fn test_registry(
     );
 
     assert_eq!(registry.read_readme("sample").await.unwrap(), None);
-    registry.add_readme("sample", "# Sample\n").await.unwrap();
+    tokio::fs::create_dir_all(module_dir.join("doc"))
+        .await
+        .unwrap();
+    tokio::fs::write(module_dir.join("doc/README.md"), "# Sample\n")
+        .await
+        .unwrap();
     assert_eq!(
         registry.read_readme("sample").await.unwrap().as_deref(),
         Some("# Sample\n")
     );
-    assert!(module_dir.join("doc/README.md").is_file());
 
     registry.remove_module("sample").await.unwrap();
     assert!(!module_dir.exists());
@@ -138,78 +142,6 @@ pub async fn test_custom_registry() {
         Default::default(),
     );
     test_registry(registry, module_dir, enabled_path, false).await;
-}
-
-#[tokio::test]
-pub async fn test_add_manifest() {
-    let base_dir = tempdir().unwrap();
-    let registry = Registry::new(base_dir.path(), Default::default());
-    registry.create_file_tree().await.unwrap();
-
-    let manifest = InstalledModuleManifest {
-        version: Some("1.2.3".into()),
-        manifest: serde_yaml_ng::from_str(SAMPLE_MANIFEST).unwrap(),
-    };
-    registry.add_manifest(manifest).await.unwrap();
-
-    let module_dir = base_dir.path().join("modules/installed/ipfs");
-    assert!(module_dir.join("manifest.json").is_file());
-
-    let module = registry.read_manifest("ipfs").await.unwrap();
-    assert_eq!(module.manifest.name, "ipfs");
-    assert_eq!(module.version.as_deref(), Some("1.2.3"));
-}
-
-#[tokio::test]
-pub async fn test_add_binary() {
-    let base_dir = tempdir().unwrap();
-    let registry = Registry::new(base_dir.path(), Default::default());
-    registry.create_file_tree().await.unwrap();
-
-    let source_path = base_dir.path().join("asimov-ipfs-fetcher");
-    tokio::fs::write(&source_path, "#!/bin/sh\n").await.unwrap();
-
-    let libexec_path = base_dir.path().join("libexec/asimov-ipfs-fetcher");
-
-    tokio::fs::write(&libexec_path, "stale").await.unwrap();
-
-    registry
-        .add_binary("ipfs", "asimov-ipfs-fetcher", &source_path)
-        .await
-        .unwrap();
-
-    let binary_path = base_dir
-        .path()
-        .join("modules/installed/ipfs/bin/asimov-ipfs-fetcher");
-    assert!(binary_path.is_file());
-
-    assert!(
-        std::fs::symlink_metadata(&libexec_path)
-            .unwrap()
-            .is_symlink()
-    );
-    assert_eq!(
-        std::fs::read_link(&libexec_path).unwrap(),
-        PathBuf::from("../modules/installed/ipfs/bin/asimov-ipfs-fetcher")
-    );
-    assert_eq!(
-        std::fs::canonicalize(&libexec_path).unwrap(),
-        std::fs::canonicalize(&binary_path).unwrap()
-    );
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mode = std::fs::metadata(&binary_path)
-            .unwrap()
-            .permissions()
-            .mode();
-        assert_eq!(mode & 0o777, 0o755);
-    }
-
-    registry.remove_binary("asimov-ipfs-fetcher").await.unwrap();
-    assert!(!libexec_path.exists());
-    assert!(binary_path.is_file());
 }
 
 #[tokio::test]

--- a/rust/lib/asimov-registry/tests/registry.rs
+++ b/rust/lib/asimov-registry/tests/registry.rs
@@ -193,6 +193,36 @@ pub async fn test_migrate_legacy_layout() {
 }
 
 #[tokio::test]
+pub async fn test_rejects_names_that_are_not_path_components() {
+    let base_dir = tempdir().unwrap();
+    let registry = Registry::new(base_dir.path(), Default::default());
+    registry.create_file_tree().await.unwrap();
+
+    // a sibling of the install directory, reachable as `../victim` from within it
+    let victim_dir = base_dir.path().join("modules/victim");
+    tokio::fs::create_dir(&victim_dir).await.unwrap();
+    tokio::fs::write(victim_dir.join("manifest.json"), SAMPLE_MANIFEST)
+        .await
+        .unwrap();
+
+    for name in ["../victim", "..", "sample/../../victim", "", "-sample"] {
+        assert!(registry.remove_module(name).await.is_err(), "{name}");
+        assert!(registry.enable_module(name).await.is_err(), "{name}");
+        assert!(registry.disable_module(name).await.is_err(), "{name}");
+        assert!(registry.remove_binary(name).await.is_err(), "{name}");
+        assert!(
+            registry
+                .add_module(name, base_dir.path().join("nonexistent"))
+                .await
+                .is_err(),
+            "{name}"
+        );
+    }
+
+    assert!(victim_dir.join("manifest.json").is_file());
+}
+
+#[tokio::test]
 pub async fn test_legacy_manifest_never_replaces_a_current_one() {
     let manifest_json = |version: &str| {
         let manifest = InstalledModuleManifest {

--- a/rust/lib/asimov-registry/tests/registry.rs
+++ b/rust/lib/asimov-registry/tests/registry.rs
@@ -57,14 +57,15 @@ pub fn compare_manifest(a: &InstalledModuleManifest, b: &InstalledModuleManifest
 
 pub async fn test_registry(
     registry: Registry,
-    installed_path: PathBuf,
+    module_dir: PathBuf,
     enabled_path: PathBuf,
     is_relative: bool,
 ) {
     registry.create_file_tree().await.unwrap();
     assert_eq!(registry.installed_modules().await.unwrap().len(), 0);
 
-    tokio::fs::write(&installed_path, SAMPLE_MANIFEST)
+    tokio::fs::create_dir_all(&module_dir).await.unwrap();
+    tokio::fs::write(module_dir.join("manifest.yaml"), SAMPLE_MANIFEST)
         .await
         .unwrap();
 
@@ -96,8 +97,20 @@ pub async fn test_registry(
     let absolute_path = std::fs::canonicalize(enabled_path.parent().unwrap().join(link_path));
     assert_eq!(
         absolute_path.unwrap(),
-        std::fs::canonicalize(&installed_path).unwrap()
+        std::fs::canonicalize(&module_dir).unwrap()
     );
+
+    assert_eq!(registry.read_readme("sample").await.unwrap(), None);
+    registry.add_readme("sample", "# Sample\n").await.unwrap();
+    assert_eq!(
+        registry.read_readme("sample").await.unwrap().as_deref(),
+        Some("# Sample\n")
+    );
+    assert!(module_dir.join("doc/README.md").is_file());
+
+    registry.remove_module("sample").await.unwrap();
+    assert!(!module_dir.exists());
+    assert_eq!(registry.installed_modules().await.unwrap().len(), 0);
 }
 
 #[tokio::test]
@@ -105,24 +118,153 @@ pub async fn test_default_registry() {
     let base_dir = tempdir().unwrap();
     let registry = Registry::new(base_dir.path(), Default::default());
 
-    let installed_path = base_dir.path().join("modules/installed/sample.yaml");
+    let module_dir = base_dir.path().join("modules/installed/sample");
     let enabled_path = base_dir.path().join("modules/enabled/sample");
 
-    test_registry(registry, installed_path, enabled_path, true).await;
+    test_registry(registry, module_dir, enabled_path, true).await;
 }
 
 #[tokio::test]
 pub async fn test_custom_registry() {
     let base_dir = tempdir().unwrap();
-    let installed_path = base_dir.path().join("a/b/c/sample.yaml");
+    let module_dir = base_dir.path().join("a/b/c/sample");
     let enabled_path = base_dir.path().join("b/sample");
     let libexec_path = base_dir.path().join("c");
 
     let registry = Registry::with_dirs(
-        installed_path.parent().unwrap(),
+        module_dir.parent().unwrap(),
         enabled_path.parent().unwrap(),
         libexec_path,
         Default::default(),
     );
-    test_registry(registry, installed_path, enabled_path, false).await;
+    test_registry(registry, module_dir, enabled_path, false).await;
+}
+
+#[tokio::test]
+pub async fn test_add_manifest() {
+    let base_dir = tempdir().unwrap();
+    let registry = Registry::new(base_dir.path(), Default::default());
+    registry.create_file_tree().await.unwrap();
+
+    let manifest = InstalledModuleManifest {
+        version: Some("1.2.3".into()),
+        manifest: serde_yaml_ng::from_str(SAMPLE_MANIFEST).unwrap(),
+    };
+    registry.add_manifest(manifest).await.unwrap();
+
+    let module_dir = base_dir.path().join("modules/installed/ipfs");
+    assert!(module_dir.join("manifest.json").is_file());
+
+    let module = registry.read_manifest("ipfs").await.unwrap();
+    assert_eq!(module.manifest.name, "ipfs");
+    assert_eq!(module.version.as_deref(), Some("1.2.3"));
+}
+
+#[tokio::test]
+pub async fn test_add_binary() {
+    let base_dir = tempdir().unwrap();
+    let registry = Registry::new(base_dir.path(), Default::default());
+    registry.create_file_tree().await.unwrap();
+
+    let source_path = base_dir.path().join("asimov-ipfs-fetcher");
+    tokio::fs::write(&source_path, "#!/bin/sh\n").await.unwrap();
+
+    let libexec_path = base_dir.path().join("libexec/asimov-ipfs-fetcher");
+
+    tokio::fs::write(&libexec_path, "stale").await.unwrap();
+
+    registry
+        .add_binary("ipfs", "asimov-ipfs-fetcher", &source_path)
+        .await
+        .unwrap();
+
+    let binary_path = base_dir
+        .path()
+        .join("modules/installed/ipfs/bin/asimov-ipfs-fetcher");
+    assert!(binary_path.is_file());
+
+    assert!(
+        std::fs::symlink_metadata(&libexec_path)
+            .unwrap()
+            .is_symlink()
+    );
+    assert_eq!(
+        std::fs::read_link(&libexec_path).unwrap(),
+        PathBuf::from("../modules/installed/ipfs/bin/asimov-ipfs-fetcher")
+    );
+    assert_eq!(
+        std::fs::canonicalize(&libexec_path).unwrap(),
+        std::fs::canonicalize(&binary_path).unwrap()
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&binary_path)
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o755);
+    }
+
+    registry.remove_binary("asimov-ipfs-fetcher").await.unwrap();
+    assert!(!libexec_path.exists());
+    assert!(binary_path.is_file());
+}
+
+#[tokio::test]
+pub async fn test_migrate_legacy_layouts() {
+    for legacy_dir in ["modules", "modules/installed"] {
+        let base_dir = tempdir().unwrap();
+        let registry = Registry::new(base_dir.path(), Default::default());
+        registry.create_file_tree().await.unwrap();
+
+        let legacy_path = base_dir.path().join(legacy_dir).join("sample.yaml");
+        tokio::fs::write(&legacy_path, SAMPLE_MANIFEST)
+            .await
+            .unwrap();
+
+        assert!(registry.is_module_installed("sample").await.unwrap());
+        registry.enable_module("sample").await.unwrap();
+
+        let module_dir = base_dir.path().join("modules/installed/sample");
+        assert!(!legacy_path.exists());
+        assert!(module_dir.join("manifest.yaml").is_file());
+        assert_eq!(registry.installed_modules().await.unwrap().len(), 1);
+        assert_eq!(registry.enabled_modules().await.unwrap().len(), 1);
+
+        let enabled_path = base_dir.path().join("modules/enabled/sample");
+        let link_path = std::fs::read_link(&enabled_path).unwrap();
+        assert_eq!(
+            std::fs::canonicalize(enabled_path.parent().unwrap().join(link_path)).unwrap(),
+            std::fs::canonicalize(&module_dir).unwrap()
+        );
+    }
+}
+
+#[tokio::test]
+pub async fn test_migrate_legacy_version() {
+    let base_dir = tempdir().unwrap();
+    let registry = Registry::new(base_dir.path(), Default::default());
+    registry.create_file_tree().await.unwrap();
+
+    let legacy_path = base_dir.path().join("modules/installed/sample.json");
+    let manifest = InstalledModuleManifest {
+        version: Some("0.1.7".into()),
+        manifest: serde_yaml_ng::from_str(SAMPLE_MANIFEST).unwrap(),
+    };
+    tokio::fs::write(&legacy_path, serde_json::to_vec(&manifest).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        registry.module_version("sample").await.unwrap().as_deref(),
+        Some("0.1.7")
+    );
+    assert!(
+        base_dir
+            .path()
+            .join("modules/installed/sample/manifest.json")
+            .is_file()
+    );
 }

--- a/rust/lib/asimov-registry/tests/registry.rs
+++ b/rust/lib/asimov-registry/tests/registry.rs
@@ -81,6 +81,8 @@ pub async fn test_registry(
     enabled_path: PathBuf,
     is_relative: bool,
 ) {
+    let sample = "sample".parse().unwrap();
+
     registry.create_file_tree().await.unwrap();
     assert_eq!(registry.installed_modules().await.unwrap().len(), 0);
 
@@ -89,7 +91,7 @@ pub async fn test_registry(
         .await
         .unwrap();
 
-    let module = registry.read_manifest("sample").await.unwrap();
+    let module = registry.read_manifest(&sample).await.unwrap();
     assert_eq!(module.manifest.name, "ipfs");
     assert_eq!(module.manifest.label.as_deref(), Some("IPFS"));
     assert_eq!(
@@ -102,7 +104,7 @@ pub async fn test_registry(
     compare_manifest(&installed_modules[0], &module);
 
     assert_eq!(registry.enabled_modules().await.unwrap().len(), 0);
-    registry.enable_module("sample").await.unwrap();
+    registry.enable_module(&sample).await.unwrap();
 
     let enabled_modules = registry.enabled_modules().await.unwrap();
     assert_eq!(enabled_modules.len(), 1);
@@ -120,7 +122,7 @@ pub async fn test_registry(
         std::fs::canonicalize(&module_dir).unwrap()
     );
 
-    assert_eq!(registry.read_readme("sample").await.unwrap(), None);
+    assert_eq!(registry.read_readme(&sample).await.unwrap(), None);
     tokio::fs::create_dir_all(module_dir.join("doc"))
         .await
         .unwrap();
@@ -128,11 +130,11 @@ pub async fn test_registry(
         .await
         .unwrap();
     assert_eq!(
-        registry.read_readme("sample").await.unwrap().as_deref(),
+        registry.read_readme(&sample).await.unwrap().as_deref(),
         Some("# Sample\n")
     );
 
-    registry.remove_module("sample").await.unwrap();
+    registry.remove_module(&sample).await.unwrap();
     assert!(!module_dir.exists());
     assert_eq!(registry.installed_modules().await.unwrap().len(), 0);
 }
@@ -170,13 +172,15 @@ pub async fn test_migrate_legacy_layout() {
     let registry = Registry::new(base_dir.path(), Default::default());
     registry.create_file_tree().await.unwrap();
 
+    let sample = "sample".parse().unwrap();
+
     let legacy_path = base_dir.path().join("modules/installed/sample.yaml");
     tokio::fs::write(&legacy_path, LEGACY_SAMPLE_MANIFEST)
         .await
         .unwrap();
 
-    assert!(registry.is_module_installed("sample").await.unwrap());
-    registry.enable_module("sample").await.unwrap();
+    assert!(registry.is_module_installed(&sample).await.unwrap());
+    registry.enable_module(&sample).await.unwrap();
 
     let module_dir = base_dir.path().join("modules/installed/sample");
     assert!(!legacy_path.exists());
@@ -193,36 +197,6 @@ pub async fn test_migrate_legacy_layout() {
 }
 
 #[tokio::test]
-pub async fn test_rejects_names_that_are_not_path_components() {
-    let base_dir = tempdir().unwrap();
-    let registry = Registry::new(base_dir.path(), Default::default());
-    registry.create_file_tree().await.unwrap();
-
-    // a sibling of the install directory, reachable as `../victim` from within it
-    let victim_dir = base_dir.path().join("modules/victim");
-    tokio::fs::create_dir(&victim_dir).await.unwrap();
-    tokio::fs::write(victim_dir.join("manifest.json"), SAMPLE_MANIFEST)
-        .await
-        .unwrap();
-
-    for name in ["../victim", "..", "sample/../../victim", "", "-sample"] {
-        assert!(registry.remove_module(name).await.is_err(), "{name}");
-        assert!(registry.enable_module(name).await.is_err(), "{name}");
-        assert!(registry.disable_module(name).await.is_err(), "{name}");
-        assert!(registry.remove_binary(name).await.is_err(), "{name}");
-        assert!(
-            registry
-                .add_module(name, base_dir.path().join("nonexistent"))
-                .await
-                .is_err(),
-            "{name}"
-        );
-    }
-
-    assert!(victim_dir.join("manifest.json").is_file());
-}
-
-#[tokio::test]
 pub async fn test_legacy_manifest_never_replaces_a_current_one() {
     let manifest_json = |version: &str| {
         let manifest = InstalledModuleManifest {
@@ -236,6 +210,8 @@ pub async fn test_legacy_manifest_never_replaces_a_current_one() {
     let registry = Registry::new(base_dir.path(), Default::default());
     registry.create_file_tree().await.unwrap();
 
+    let sample = "sample".parse().unwrap();
+
     let module_dir = base_dir.path().join("modules/installed/sample");
     tokio::fs::create_dir(&module_dir).await.unwrap();
     tokio::fs::write(module_dir.join("manifest.json"), manifest_json("2.0.0"))
@@ -248,7 +224,7 @@ pub async fn test_legacy_manifest_never_replaces_a_current_one() {
         .unwrap();
 
     assert_eq!(
-        registry.module_version("sample").await.unwrap().as_deref(),
+        registry.module_version(&sample).await.unwrap().as_deref(),
         Some("2.0.0")
     );
     assert!(!legacy_path.exists());
@@ -261,6 +237,8 @@ pub async fn test_migrate_legacy_version() {
     let registry = Registry::new(base_dir.path(), Default::default());
     registry.create_file_tree().await.unwrap();
 
+    let sample = "sample".parse().unwrap();
+
     let legacy_path = base_dir.path().join("modules/installed/sample.json");
     let manifest = InstalledModuleManifest {
         version: Some("0.1.7".into()),
@@ -271,7 +249,7 @@ pub async fn test_migrate_legacy_version() {
         .unwrap();
 
     assert_eq!(
-        registry.module_version("sample").await.unwrap().as_deref(),
+        registry.module_version(&sample).await.unwrap().as_deref(),
         Some("0.1.7")
     );
     assert!(

--- a/rust/lib/asimov-registry/tests/registry.rs
+++ b/rust/lib/asimov-registry/tests/registry.rs
@@ -4,7 +4,27 @@ use asimov_module::InstalledModuleManifest;
 use asimov_registry::Registry;
 use tempfile::tempdir;
 
-const SAMPLE_MANIFEST: &str = r#"# See: https://asimov-specs.github.io/module-manifest/
+// See: https://asimov-specs.github.io/module-manifest/
+const SAMPLE_MANIFEST: &str = r#"{
+  "name": "ipfs",
+  "label": "IPFS",
+  "title": "ASIMOV IPFS Module",
+  "summary": "IPFS protocol support.",
+  "links": [
+    "https://github.com/asimov-modules/asimov-ipfs-module",
+    "https://crates.io/crates/asimov-ipfs-module"
+  ],
+  "provides": {
+    "programs": ["asimov-ipfs-fetcher"]
+  },
+  "handles": {
+    "url_protocols": ["ipfs"]
+  }
+}
+"#;
+
+/// Manifests were YAML back when they lived directly in the modules directory.
+const LEGACY_SAMPLE_MANIFEST: &str = r#"# See: https://asimov-specs.github.io/module-manifest/
 ---
 name: ipfs
 label: IPFS
@@ -65,7 +85,7 @@ pub async fn test_registry(
     assert_eq!(registry.installed_modules().await.unwrap().len(), 0);
 
     tokio::fs::create_dir_all(&module_dir).await.unwrap();
-    tokio::fs::write(module_dir.join("manifest.yaml"), SAMPLE_MANIFEST)
+    tokio::fs::write(module_dir.join("manifest.json"), SAMPLE_MANIFEST)
         .await
         .unwrap();
 
@@ -152,7 +172,7 @@ pub async fn test_migrate_legacy_layouts() {
         registry.create_file_tree().await.unwrap();
 
         let legacy_path = base_dir.path().join(legacy_dir).join("sample.yaml");
-        tokio::fs::write(&legacy_path, SAMPLE_MANIFEST)
+        tokio::fs::write(&legacy_path, LEGACY_SAMPLE_MANIFEST)
             .await
             .unwrap();
 
@@ -161,7 +181,7 @@ pub async fn test_migrate_legacy_layouts() {
 
         let module_dir = base_dir.path().join("modules/installed/sample");
         assert!(!legacy_path.exists());
-        assert!(module_dir.join("manifest.yaml").is_file());
+        assert!(module_dir.join("manifest.json").is_file());
         assert_eq!(registry.installed_modules().await.unwrap().len(), 1);
         assert_eq!(registry.enabled_modules().await.unwrap().len(), 1);
 
@@ -183,7 +203,7 @@ pub async fn test_migrate_legacy_version() {
     let legacy_path = base_dir.path().join("modules/installed/sample.json");
     let manifest = InstalledModuleManifest {
         version: Some("0.1.7".into()),
-        manifest: serde_yaml_ng::from_str(SAMPLE_MANIFEST).unwrap(),
+        manifest: serde_json::from_str(SAMPLE_MANIFEST).unwrap(),
     };
     tokio::fs::write(&legacy_path, serde_json::to_vec(&manifest).unwrap())
         .await

--- a/rust/lib/asimov-snapshot/src/snapshot.rs
+++ b/rust/lib/asimov-snapshot/src/snapshot.rs
@@ -5,7 +5,7 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use asimov_module::resolve::Resolver;
+use asimov_module::{ModuleName, resolve::Resolver};
 use asimov_registry::Registry;
 use asimov_runner::GraphOutput;
 use jiff::{Span, Timestamp, ToSpan};
@@ -90,9 +90,11 @@ impl<S: crate::storage::Storage> Snapshotter<S> {
             .cloned()
             .ok_or_else(|| std::io::Error::other("No module found for creating snapshot"))?;
 
+        let module_name = ModuleName::try_from(module.name.clone()).map_err(io::Error::other)?;
+
         let programs = self
             .registry
-            .read_manifest(&module.name)
+            .read_manifest(&module_name)
             .await
             .map_err(io::Error::other)?
             .manifest


### PR DESCRIPTION
- Makes module installs to `~/.asimov/modules/installed/<name>/{manifest.json,bin/,doc/README.md}`
  - Binaries are linked to from `libexec/`
- Drops support for the oldest format `~/.asimov/modules/foobar.yaml`, the second oldest `~/.asimov/modules/installed/foobar.yaml` are automatically migrated to the directory format.
- README is downloaded with install
  - accessible through `Registry::read_readme` for now, we'll update once we know what other "docs" we'd like available
  - README reads are attempted in order 1. tarball `/readme.md` 2. github with release tag 3. github with trunk branches (master, main)
- Improves install atomicity and removes a redundant copy

<!-- Thank you for your valuable contribution to ASIMOV -->
